### PR TITLE
ci: fix pre-release checks – remove unsupported uv config, fix docs theme import, add build dependency

### DIFF
--- a/.github/workflows/pr-contracts.yml
+++ b/.github/workflows/pr-contracts.yml
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@v1
 
       - name: Sync Python dependencies
-        run: uv sync
+        run: uv sync --dev
 
       - name: Install pnpm
         run: npm i -g pnpm@10.16.1

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v1
 
       - name: Sync Python dependencies
-        run: uv sync
+        run: uv sync --dev
 
       - name: Install pnpm
         run: npm i -g pnpm@10.16.1

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import type { DocsThemeConfig } from 'nextra-theme-docs'
 
-const themeConfig: DocsThemeConfig = {
+const themeConfig = {
   logo: (
     <div className="flex items-center gap-2 font-semibold leading-none text-slate-100">
       <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-gradient-to-br from-[#7c3aed] via-[#6366f1] to-[#22d3ee] text-base text-white shadow-[0_0_18px_rgba(99,102,241,0.45)]">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
   "jsonschema>=4.21",
   "ruff>=0.5",
   "import-linter>=2.0",
+  "build>=1.0.0",
 ]
 langgraph = [
   "langgraph>=0.0.45",
@@ -46,6 +47,7 @@ dev = [
   "jsonschema>=4.21",
   "ruff>=0.5",
   "import-linter>=2.0",
+  "build>=1.0.0",
 ]
 ui = [
   "rich>=14.2.0",
@@ -54,9 +56,6 @@ ui = [
   "streamlit>=1.51.0",
 ]
 migrate = ["libcst>=1.5.0"]
-
-[tool.uv]
-default-groups = ["dev"]
 
 [project.scripts]
 noesis = "noesis.cli.__main__:main"

--- a/scripts/pre_release.py
+++ b/scripts/pre_release.py
@@ -74,7 +74,7 @@ CHECKS: List[Check] = [
     ),
     Check(
         name="build-wheel",
-        command=["uv", "build"],
+        command=["uv", "run", "python", "-m", "build"],
         description="Build distribution artifacts to confirm packaging health.",
     ),
 ]


### PR DESCRIPTION
This patch stabilizes the release pipeline:

• Removes `[tool.uv].default-groups` (unsupported in older CI runners).
• Replaces `uv build` with a portable build step using `python -m build`.
• Fixes docs build type error by adjusting Nextra theme import.
• Ensures build dependency is available before packaging check.

Outcome:
Both PR and tag workflows should now complete end-to-end, with working docs and wheel build gates.