### PR TITLE
ci: install dev group for release contracts

### DIFF
--- a/scripts/pre_release.py
+++ b/scripts/pre_release.py
@@ -27,7 +27,7 @@ class Check:
 CHECKS: List[Check] = [
     Check(
         name="unit-tests",
-        command=["uv", "run", "python", "-m", "pytest"],
+        command=["uv", "run", "--group", "dev", "python", "-m", "pytest"],
         description="Execute the full Python test suite.",
     ),
     Check(
@@ -74,7 +74,7 @@ CHECKS: List[Check] = [
     ),
     Check(
         name="build-wheel",
-        command=["uv", "run", "python", "-m", "build"],
+        command=["uv", "run", "--group", "dev", "python", "-m", "build"],
         description="Build distribution artifacts to confirm packaging health.",
     ),
 ]


### PR DESCRIPTION
This PR fixes the failing **Release Contracts** workflow by ensuring dev tools
are available when pre-release checks run under CI.

### What changed

- **Unit tests check**
  - Run via `uv run --group dev python -m pytest` so `pytest` is always
    available from the `dev` dependency group.

- **Build wheel check**
  - Run via `uv run --group dev python -m build` so the `build` package is
    installed before building distribution artifacts.

- Other checks remain on the base runtime dependencies to avoid unnecessary
  dev installs.

### Why

Previously, the `build-wheel` step failed with:

> No module named build

because the `build` package only lived in the `dev` dependency group and was
never installed in CI. Wiring `--group dev` into these `uv run` commands aligns
the Release Contracts workflow with `pyproject.toml` and keeps the pre-release
checks green.