### PR TITLE
config: add prompt provenance flags to runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![PR Contracts](https://github.com/saraeloop/noesis/actions/workflows/pr-contracts.yml/badge.svg)](https://github.com/saraeloop/noesis/actions/workflows/pr-contracts.yml)
 [![Release Prep](https://github.com/saraeloop/noesis/actions/workflows/release-prep.yml/badge.svg)](https://github.com/saraeloop/noesis/actions/workflows/release-prep.yml)
 [![Stars](https://img.shields.io/github/stars/saraeloop/noesis?style=social)](https://github.com/saraeloop/noesis/stargazers)
-[![Docs](https://img.shields.io/badge/docs-DeepWiki%20overview-0f766e)](https://deepwiki.com/saraeloop/noesis)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/saraeloop/noesis)
 [![Planner Modes](https://img.shields.io/badge/planner-meta%20%E2%80%A2%20minimal-0ea5e9)](#learner-flow)
 [![Python](https://img.shields.io/badge/python-3.11+-18181b)](pyproject.toml)

--- a/noesis/domain/config/settings.py
+++ b/noesis/domain/config/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Literal
 
 from noesis.domain.faculties.intuition import IntuitionMode
 from noesis.domain.learning.model import LearnMode
@@ -24,6 +24,8 @@ ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(
         "learn_home",
         "learn_auto_apply_min_successes",
         "learn_auto_apply_min_confidence",
+        "prompt_provenance_enabled",
+        "prompt_provenance_mode",
     }
 )
 
@@ -44,6 +46,8 @@ class RuntimeConfig:
     learn_home: Path
     learn_auto_apply_min_successes: int
     learn_auto_apply_min_confidence: float
+    prompt_provenance_enabled: bool
+    prompt_provenance_mode: Literal["full", "hash_only"]
 
 
 def default_runtime_config() -> RuntimeConfig:
@@ -61,6 +65,8 @@ def default_runtime_config() -> RuntimeConfig:
         learn_home=Path.home() / ".noesis" / "state",
         learn_auto_apply_min_successes=3,
         learn_auto_apply_min_confidence=0.75,
+        prompt_provenance_enabled=False,
+        prompt_provenance_mode="hash_only",
     )
 
 
@@ -124,6 +130,10 @@ def apply_runtime_overrides(
                     "learn_auto_apply_min_confidence",
                 ),
             )
+        elif key == "prompt_provenance_enabled":
+            updated = replace(updated, prompt_provenance_enabled=_parse_bool(value, "prompt_provenance_enabled"))
+        elif key == "prompt_provenance_mode":
+            updated = replace(updated, prompt_provenance_mode=_parse_provenance_mode(value))
     return updated
 
 
@@ -159,3 +169,23 @@ def _bounded_float(value: object, label: str) -> float:
     if not (0.0 <= number <= 1.0):
         raise ValueError(f"{label} must be within [0.0, 1.0]")
     return number
+
+
+def _parse_bool(value: object, label: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise TypeError(f"{label} must be a bool-compatible value, got {value!r}")
+
+
+def _parse_provenance_mode(value: object) -> Literal["full", "hash_only"]:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("full", "hash_only"):
+            return "full" if normalized == "full" else "hash_only"
+    raise ValueError("prompt_provenance_mode must be 'full' or 'hash_only'")

--- a/noesis/infrastructure/config/loader.py
+++ b/noesis/infrastructure/config/loader.py
@@ -37,6 +37,8 @@ _ENV_KEY_MAP: dict[str, str] = {
     "NOESIS_LEARN_HOME": "learn_home",
     "NOESIS_LEARN_AUTO_APPLY_MIN_SUCCESSES": "learn_auto_apply_min_successes",
     "NOESIS_LEARN_AUTO_APPLY_MIN_CONFIDENCE": "learn_auto_apply_min_confidence",
+    "NOESIS_PROMPT_PROVENANCE_ENABLED": "prompt_provenance_enabled",
+    "NOESIS_PROMPT_PROVENANCE_MODE": "prompt_provenance_mode",
 }
 
 
@@ -145,6 +147,8 @@ class EnvTomlConfig(ConfigPort):
             learn_home=config.learn_home,
             learn_auto_apply_min_successes=config.learn_auto_apply_min_successes,
             learn_auto_apply_min_confidence=config.learn_auto_apply_min_confidence,
+            prompt_provenance_enabled=config.prompt_provenance_enabled,
+            prompt_provenance_mode=config.prompt_provenance_mode,
         )
 
     @staticmethod

--- a/noesis/interfaces/config.py
+++ b/noesis/interfaces/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Mapping, Protocol
+from typing import Any, Dict, Literal, Mapping, Protocol
 
 from noesis.domain.faculties.intuition import IntuitionMode
 from noesis.domain.learning.model import LearnMode
@@ -34,6 +34,8 @@ class ConfigSnapshot:
     learn_home: Path
     learn_auto_apply_min_successes: int
     learn_auto_apply_min_confidence: float
+    prompt_provenance_enabled: bool
+    prompt_provenance_mode: Literal["full", "hash_only"]
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, object]) -> "ConfigSnapshot":
@@ -59,6 +61,24 @@ class ConfigSnapshot:
                 return PlannerMode(raw.lower().strip())
             raise TypeError(f"Unsupported planner_mode value: {raw!r}")
 
+        def _bool_value(raw: Any, label: str) -> bool:
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, str):
+                normalized = raw.strip().lower()
+                if normalized in {"1", "true", "yes", "on"}:
+                    return True
+                if normalized in {"0", "false", "no", "off"}:
+                    return False
+            raise TypeError(f"Unsupported {label} value: {raw!r}")
+
+        def _prompt_mode(raw: Any) -> Literal["full", "hash_only"]:
+            if isinstance(raw, str):
+                normalized = raw.strip().lower()
+                if normalized in {"full", "hash_only"}:
+                    return "full" if normalized == "full" else "hash_only"
+            raise TypeError(f"prompt_provenance_mode must be 'full' or 'hash_only', got: {raw!r}")
+
         raw_aliases = data.get("policy_aliases", {})
         if raw_aliases is None:
             raw_aliases = {}
@@ -82,6 +102,13 @@ class ConfigSnapshot:
             learn_auto_apply_min_confidence=float(
                 data["learn_auto_apply_min_confidence"]
             ),
+            prompt_provenance_enabled=_bool_value(
+                data.get("prompt_provenance_enabled", False),
+                "prompt_provenance_enabled",
+            ),
+            prompt_provenance_mode=_prompt_mode(
+                data.get("prompt_provenance_mode", "hash_only")
+            ),
         )
 
     def to_mapping(self) -> Dict[str, object]:
@@ -103,6 +130,8 @@ class ConfigSnapshot:
             "learn_auto_apply_min_confidence": float(
                 self.learn_auto_apply_min_confidence
             ),
+            "prompt_provenance_enabled": self.prompt_provenance_enabled,
+            "prompt_provenance_mode": self.prompt_provenance_mode,
         }
 
 

--- a/tests/runtime/test_determinism.py
+++ b/tests/runtime/test_determinism.py
@@ -51,6 +51,8 @@ def _config_snapshot(tmp_path: Path) -> ConfigSnapshot:
         "learn_home": str(learn_home),
         "learn_auto_apply_min_successes": 1,
         "learn_auto_apply_min_confidence": 0.5,
+        "prompt_provenance_enabled": False,
+        "prompt_provenance_mode": "hash_only",
     }
     return ConfigSnapshot.from_mapping(payload)
 

--- a/tests/runtime/test_session.py
+++ b/tests/runtime/test_session.py
@@ -66,6 +66,8 @@ def _snapshot_for(tmp_path: Path, *, planner: PlannerMode = PlannerMode.MINIMAL)
         "learn_home": str(learn_home),
         "learn_auto_apply_min_successes": 1,
         "learn_auto_apply_min_confidence": 0.5,
+        "prompt_provenance_enabled": False,
+        "prompt_provenance_mode": "hash_only",
     }
     return ConfigSnapshot.from_mapping(payload)
 

--- a/tests/usecases/test_memory_sync.py
+++ b/tests/usecases/test_memory_sync.py
@@ -65,11 +65,14 @@ def _runtime_context(tmp_path: Path) -> RuntimeContext:
             "timeout_sec": 60,
             "intuition_mode": "advisory",
             "direction_min_confidence": 0.5,
+            "planner_mode": "minimal",
             "policy_aliases": {},
             "learn_mode": "off",
             "learn_home": str(tmp_path / "learn"),
             "learn_auto_apply_min_successes": 1,
             "learn_auto_apply_min_confidence": 0.8,
+            "prompt_provenance_enabled": False,
+            "prompt_provenance_mode": "hash_only",
         }
     )
     context = RuntimeContext(config_port=DummyConfigPort(snapshot))


### PR DESCRIPTION
## Summary

This PR adds the **configuration surface for Prompt Provenance (ADR-005)** without changing runtime behavior yet. Prompt provenance is now modeled as a first-class feature in the runtime config, but remains **disabled by default**.

These flags will be used by the upcoming `PromptRecorder` / `prompts.jsonl` plumbing.

---

## What changed

### 1. Runtime config surface

- Extend the domain config with two new fields:

  - `prompt_provenance_enabled: bool`
  - `prompt_provenance_mode: Literal["full", "hash_only"]`

- Defaults (no behavior change until explicitly enabled):

  - `prompt_provenance_enabled = False`
  - `prompt_provenance_mode = "hash_only"`

This keeps prompt provenance **opt-in** and allows deployments to choose full vs hash-only recording when we wire the recorder.

---

### 2. ConfigSnapshot and ports

- `ConfigSnapshot` now exposes:
  - `prompt_provenance_enabled: bool`
  - `prompt_provenance_mode: Literal["full", "hash_only"]`

- `ConfigSnapshot.from_mapping(...)`:
  - Normalizes booleans from env/TOML/ns.set using `_bool_value(...)`.
  - Accepts `"full"` and `"hash_only"` (case-insensitive) for `prompt_provenance_mode`.
  - Fails fast on invalid values (`TypeError`) to avoid silent misconfigurations.

- `ConfigSnapshot.to_mapping()` includes `prompt_provenance_*` in the plain dict representation so sessions and runtime components can branch on the flags without touching env directly.

This aligns with the existing clean architecture boundary where **ConfigPort** is the only way to see configuration in the runtime.

---

### 3. Env/TOML loader integration

- `EnvTomlConfig` / config loader now recognize:

  - `NOESIS_PROMPT_PROVENANCE_ENABLED` → `prompt_provenance_enabled`
  - `NOESIS_PROMPT_PROVENANCE_MODE` → `prompt_provenance_mode`

- TOML-based config already flows through `ALLOWED_CONFIG_KEYS`, so the new fields are available via:

  ```toml
  prompt_provenance_enabled = true
  prompt_provenance_mode = "full"