### PR TITLE
feat(runtime): add PromptRecorder skeleton and episode-level provenance flags

### DIFF
--- a/noesis/core.py
+++ b/noesis/core.py
@@ -54,6 +54,7 @@ from copy import deepcopy
 from .runtime.utils import now as _now
 from .runtime.clock import RuntimeClock
 from .runtime.events_emitter import CognitiveEventEmitter
+from .runtime.prompt_recorder import PromptRecorder
 from .runtime.events import (
     act_event as _act_event,
     ensure_act_event as _ensure_act_event,
@@ -476,7 +477,10 @@ def _run_impl(
         tags=tags or {},
         adapter_label=adapter_label,
         started_at=ctx.started_at,
+        prompt_provenance_enabled=cfg.prompt_provenance_enabled,
+        prompt_provenance_mode=cfg.prompt_provenance_mode,
     )
+    episode_ctx.prompt_recorder = PromptRecorder.from_context(episode_ctx)
     state_repo = RuntimeStateRepository(context=episode_ctx)
     state = state_repo.init()
     state_path = ctx.run_dir / "state.json"

--- a/noesis/infrastructure/state_repository.py
+++ b/noesis/infrastructure/state_repository.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol, TYPE_CHECKING
+
 from noesis.runtime.serialization import atomic_write_json
 from noesis.domain.state import NoesisState, create_state
+
+if TYPE_CHECKING:
+    from noesis.runtime.prompt_recorder import PromptRecorder
 
 
 class StateRepository(Protocol):
@@ -33,6 +37,9 @@ class EpisodeContext:
     tags: dict[str, object]
     adapter_label: str
     started_at: str
+    prompt_provenance_enabled: bool = False
+    prompt_provenance_mode: Literal["full", "hash_only"] = "hash_only"
+    prompt_recorder: "PromptRecorder | None" = None
 
 
 @dataclass(slots=True)

--- a/noesis/runtime/prompt_recorder.py
+++ b/noesis/runtime/prompt_recorder.py
@@ -1,0 +1,59 @@
+"""
+Prompt provenance recorder skeleton (ADR-005).
+
+This utility will eventually stream prompt metadata into `prompts.jsonl`.
+For v0.1 it only reflects configuration so call sites can branch on
+`enabled` and `mode` without touching file I/O yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from noesis.infrastructure.state_repository import EpisodeContext
+
+PromptProvenanceMode = Literal["full", "hash_only"]
+
+__all__ = ["PromptRecorder", "PromptProvenanceMode"]
+
+
+@dataclass(slots=True)
+class PromptRecorder:
+    """Minimal prompt recorder facade used by the runtime."""
+
+    run_dir: Path
+    episode_id: str
+    enabled: bool
+    mode: PromptProvenanceMode
+
+    @classmethod
+    def from_context(cls, context: "EpisodeContext") -> "PromptRecorder":
+        """
+        Build a recorder by inspecting episode-level provenance settings.
+
+        The recorder keeps a reference to the run directory and episode ID so
+        future iterations can emit `prompts.jsonl` without additional wiring.
+        """
+        return cls(
+            run_dir=context.run_dir,
+            episode_id=context.episode_id,
+            enabled=context.prompt_provenance_enabled,
+            mode=context.prompt_provenance_mode,
+        )
+
+    def is_enabled(self) -> bool:
+        """Return True when prompt provenance capture should run."""
+        return self.enabled
+
+    def record(self, **_: object) -> None:
+        """
+        Placeholder recording hook.
+
+        Future versions will hash and persist prompt bodies. For now we no-op,
+        which keeps deterministic behavior unchanged while the feature flag is off.
+        """
+        return None
+

--- a/tests/runtime/test_prompt_recorder.py
+++ b/tests/runtime/test_prompt_recorder.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from noesis.infrastructure.state_repository import EpisodeContext
+from noesis.runtime.prompt_recorder import PromptRecorder
+
+
+Mode = Literal["full", "hash_only"]
+
+
+def _context(tmp_path: Path, *, enabled: bool, mode: Mode) -> EpisodeContext:
+    return EpisodeContext(
+        run_dir=tmp_path,
+        episode_id="ep_test",
+        seed=0,
+        task="demo",
+        tags={},
+        adapter_label="adapter:core",
+        started_at="2025-01-01T00:00:00Z",
+        prompt_provenance_enabled=enabled,
+        prompt_provenance_mode=mode,
+    )
+
+
+def test_prompt_recorder_disabled(tmp_path: Path) -> None:
+    recorder = PromptRecorder.from_context(_context(tmp_path, enabled=False, mode="hash_only"))
+    assert recorder.is_enabled() is False
+    assert recorder.mode == "hash_only"
+    # The skeleton no-ops even when invoked.
+    recorder.record(phase="plan")
+
+
+def test_prompt_recorder_enabled_full_mode(tmp_path: Path) -> None:
+    recorder = PromptRecorder.from_context(_context(tmp_path, enabled=True, mode="full"))
+    assert recorder.is_enabled() is True
+    assert recorder.mode == "full"
+


### PR DESCRIPTION

## Summary

Introduce the initial **Prompt Provenance** runtime surface for ADR-005:

- Expose prompt provenance flags on the episode context, derived from the runtime config.
- Introduce a `PromptRecorder` skeleton that hangs off the episode context.
- Keep behavior strictly no-op for now (no file I/O, no new artifacts).

This lays the groundwork for `prompts.jsonl` without touching determinism or existing replay guarantees.

## Changes

### 1. Episode context

- Extend `EpisodeContext` to carry:
  - `prompt_provenance_enabled: bool`
  - `prompt_provenance_mode: Literal["full", "hash_only"]`

- Ensure these values are populated from the existing runtime config snapshot so runtime code can ask “is provenance enabled?” and “which mode?” without reaching back into config ports.

### 2. PromptRecorder skeleton

- Add `noesis/runtime/prompt_recorder.py` with:

  ```python
  from dataclasses import dataclass
  from pathlib import Path
  from typing import Literal, TYPE_CHECKING

  if TYPE_CHECKING:
      from noesis.infrastructure.state_repository import EpisodeContext

  PromptProvenanceMode = Literal["full", "hash_only"]

  @dataclass(slots=True)
  class PromptRecorder:
      run_dir: Path
      episode_id: str
      enabled: bool
      mode: PromptProvenanceMode

      @classmethod
      def from_context(cls, context: "EpisodeContext") -> "PromptRecorder":
          return cls(
              run_dir=context.run_dir,
              episode_id=context.episode_id,
              enabled=context.prompt_provenance_enabled,
              mode=context.prompt_provenance_mode,
          )

      def is_enabled(self) -> bool:
          return self.enabled

      def record(self, **_: object) -> None:
          # v0.1: placeholder, no file I/O yet
          return None

  •	_run_impl in noesis/core.py now constructs an EpisodeContext with the provenance flags so future call sites can obtain a recorder via PromptRecorder.from_context(...) without reaching into global config.
  ```

3. Tests
   • Add tests/runtime/test_prompt_recorder.py to verify:
   • PromptRecorder.from_context(...) reflects enabled and mode correctly.
   • is_enabled() responds as expected for both "full" and "hash_only".
   • record() is a safe no-op placeholder (no exceptions, no side effects).

## Why

ADR-005 defines prompts.jsonl as an optional, schema-governed artifact.
This PR only delivers the foundation:
• Episode-level context knows whether prompt capture is enabled and in which mode.
• A typed PromptRecorder exists for the runtime to depend on, but does not write files yet.
• Config + flags remain part of the normal runtime configuration surface and are now visible to episodes.

This keeps:
• Determinism and replay (ADR-004) unchanged.
• Artifacts and manifests (ADR-002/003) untouched for now.
• Future wiring (planner / governance / reflection call sites + schema + prompts.jsonl) smaller and more focused.


## Behavioral impact
• Default behavior is unchanged:
• prompt_provenance_enabled defaults to False.
• prompt_provenance_mode defaults to "hash_only" when enabled.
• No new files are written.
• No changes to manifest.json, events.jsonl, summary.json, or state.json.

## Next steps (follow-up PRs)
• Implement real PromptRecorder.record(...) that:
• Normalizes and hashes rendered prompts.
• Writes line-oriented JSON into prompts.jsonl under the episode run dir.
• Integrates with the deterministic clock when DeterminismConfig is present.
• Wire the recorder into Noēsis-owned LLM call sites:
• Planner / direction.
• Governance.
• Reflection.
• Add schema + guard:
• internal_docs/schema/prompt.yaml
• Generated docs/schema/prompt.schema.json
• CI fixtures + schema_guard coverage for the new prompt artifact.
