### PR TITLE
docs(runs): document prompt provenance and add manifest tamper coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 build/
 .eggs/
 runs/
+!docs/runs/
+!docs/runs/README.md
 .noesis/
 .pytest_cache/
 .coverage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -186,8 +186,8 @@ Every update strengthens three dimensions:
 
 **Exit Criteria (for v0.1)**
 
-- When `prompt_provenance_enabled=true`, `prompts.jsonl` is created for at least one example scenario.
-- Lines contain the minimal field set and join correctly on `episode_id`.
+- When `prompt_provenance_enabled=true`, `prompts.jsonl` is created for at least one example scenario. ✅
+- Lines contain the minimal field set and join correctly on `episode_id`. ✅
 - A small deterministic test case asserts identical `prompts.jsonl` between two runs under the same `DeterminismConfig` (or the feature is explicitly disabled in deterministic mode for v1.0.0).
 
 > **Note:** Phase 2.5 is explicitly **non-blocking** for the v1.0.0 release gate. It can be skipped if capacity is tight; ADR-005 remains Proposed/Experimental and is fully realized in v1.1+.

--- a/docs/artifacts/state.md
+++ b/docs/artifacts/state.md
@@ -21,5 +21,5 @@ Noēsis writes a `state.json` file for every episode inside `runs/<label>/<episo
 ## Where to look next
 
 - [examples/artifacts/state_v1_example.json](../../examples/artifacts/state_v1_example.json) – canonical demo state pulled into the README.
-- [runs/README.md](../../runs/README.md) – folder-level primer on how `state.json`, `summary.json`, and `events.jsonl` interlock.
+- [runs/README.md](../runs/README.md) – folder-level primer on how `state.json`, `summary.json`, and `events.jsonl` interlock.
 - `noesis view <run_dir>` – CLI visualizer that converts the same JSON into annotated timelines for stakeholder reviews.

--- a/docs/runs/README.md
+++ b/docs/runs/README.md
@@ -1,0 +1,25 @@
+# Episode Run Artifacts
+
+Every episode writes immutable artifacts under `runs/<label>/<episode_id>/`. These files are append-only until `manifest.json` is sealed.
+
+- `events.jsonl` — chronological cognitive events (observe/interpret/plan/act/reflect/learn) with lineage.
+- `state.json` — structured episode state (goal, plan, actions, outcomes, links).
+- `summary.json` — condensed episode summary and KPIs.
+- `prompts.jsonl` — **experimental** prompt provenance (ADR-005, optional, behind `prompt_provenance_enabled`). Each line is a schema-tagged prompt record with `episode_id`, `phase`, `agent_id`, `fingerprint`, and (in `full` mode) the rendered prompt body.
+
+When a run finishes, `manifest.json` captures integrity metadata for every artifact. Example (truncated SHA values):
+
+```json
+{
+  "episode_id": "ep_01KARXTHS68GAYWGR2588QW2YJ",
+  "schema_version": "manifest/1.0",
+  "files": [
+    { "kind": "events", "name": "events.jsonl", "sha256": "sha256:647d1f86...", "size_bytes": 7045 },
+    { "kind": "state", "name": "state.json", "sha256": "sha256:a87f1e5e...", "size_bytes": 1637 },
+    { "kind": "summary", "name": "summary.json", "sha256": "sha256:b5cf1cc8...", "size_bytes": 1265 },
+    { "kind": "attachment", "name": "prompts.jsonl", "sha256": "sha256:a4099f6d...", "size_bytes": 537 }
+  ]
+}
+```
+
+Use `noesis artifacts verify <run_dir>` (or `noesis.artifacts.verify_manifest`) to re-hash files and detect tampering. Prompt provenance stays opt-in; turn it on via `prompt_provenance_enabled=true` and choose `prompt_provenance_mode` (`full` or `hash_only`).

--- a/internal_docs/releases/v1.0.0-release-checklist.md
+++ b/internal_docs/releases/v1.0.0-release-checklist.md
@@ -79,12 +79,12 @@ Everything else (SBOMs, OTLP, policy audits, fancy TUI) is 1.1+.
 
 ## 4. Prompt Provenance v0.1 (Optional)
 
-- [ ] `prompt_provenance_enabled` feature flag exists and defaults are sane.
-- [ ] When enabled, `prompts.jsonl` is created with at least:
-  - [ ] `episode_id`, `phase`, `agent_id`, `rendered`, `fingerprint`, `timestamp`, `model`, `mode`.
+- [x] `prompt_provenance_enabled` feature flag exists and defaults are sane.
+- [x] When enabled, `prompts.jsonl` is created with at least:
+  - [x] `episode_id`, `phase`, `agent_id`, `rendered`, `fingerprint`, `timestamp`, `model`, `mode`.
 - [ ] A small deterministic test confirms `prompts.jsonl` is identical across two runs under `DeterminismConfig`  
   _or_ the feature is documented as disabled in deterministic mode for 1.0.
-- [ ] Docs clearly mark prompt provenance as **experimental** and **optional**.
+- [x] Docs clearly mark prompt provenance as **experimental** and **optional**.
 
 ---
 

--- a/tests/runtime/test_artifacts.py
+++ b/tests/runtime/test_artifacts.py
@@ -58,6 +58,22 @@ def test_manifest_verifier_detects_tampering(tmp_path: Path, filename: str) -> N
     assert any(issue.name == filename for issue in tamper_report.issues)
 
 
+def test_manifest_verifier_detects_prompt_tampering(tmp_path: Path) -> None:
+    run_dir = _prepare_run_dir(tmp_path, "ep_prompt")
+    (run_dir / "prompts.jsonl").write_text('{"prompt": "original"}\n', encoding="utf-8")
+
+    writer = ManifestWriter(run_dir=run_dir, episode_id="ep_prompt")
+    writer.finalize()
+
+    verifier = ManifestVerifier(run_dir=run_dir)
+    assert verifier.verify_path(run_dir / MANIFEST_FILE_NAME).status == "ok"
+
+    (run_dir / "prompts.jsonl").write_text('{"prompt": "tampered"}\n', encoding="utf-8")
+    tamper_report = verifier.verify_path(run_dir / MANIFEST_FILE_NAME)
+    assert tamper_report.status == "error"
+    assert any(issue.name == "prompts.jsonl" for issue in tamper_report.issues)
+
+
 def test_manifest_verifier_reports_missing_file(tmp_path: Path) -> None:
     run_dir = _prepare_run_dir(tmp_path, "ep_missing")
     writer = ManifestWriter(run_dir=run_dir, episode_id="ep_missing")


### PR DESCRIPTION
## Summary

Tie ADR-005 (Prompt Provenance) into the docs, release checklist, and manifest
verification, so `prompts.jsonl` is treated like a first-class artifact without
changing default runtime behavior.

- Document `prompts.jsonl` as an **experimental**, opt-in artifact in the runs
  docs and show how it appears in `manifest.json`.
- Mark the prompt-provenance v0.1 checklist items as completed where criteria
  are met.
- Extend the manifest verifier tests to catch tampering of `prompts.jsonl`.

---

## Changes

### 1. Docs: run artifacts and prompt provenance

- Update `docs/runs/README.md` with an “Episode Run Artifacts” section:
  - Describe `events.jsonl`, `state.json`, `summary.json`, and
    `prompts.jsonl` (experimental, behind `prompt_provenance_enabled`).
  - Show a `manifest.json` snippet that includes `prompts.jsonl` as an
    `"attachment"` with `sha256` and `size_bytes`.
  - Mention `noesis artifacts verify <run_dir>` /
    `noesis.artifacts.verify_manifest` as the way to detect tampering.
- Fix the `docs/artifacts/state.md` link to point to `../runs/README.md`.
- Allow `docs/runs/` and `docs/runs/README.md` through `.gitignore` via
  negation rules so the docs are tracked.

### 2. v1.0.0 checklist alignment

- Update `internal_docs/v1.0.0-release-checklist.md` “Prompt Provenance v0.1”
  section:
  - Mark as completed:
    - `prompt_provenance_enabled` flag + sane defaults.
    - Creation of `prompts.jsonl` with the minimal field set:
      `episode_id`, `phase`, `agent_id`, `rendered`, `fingerprint`,
      `timestamp`, `model`, `mode`.
    - Documentation clearly labeling prompt provenance as
      **experimental** and **optional**.
  - Leave the determinism-focused checkbox open for follow-up
    (or explicit disablement in deterministic mode).

### 3. Manifest tamper coverage for prompts.jsonl

- Extend `tests/runtime/test_artifacts.py`:
  - Add `test_manifest_verifier_detects_prompt_tampering`:
    - Create a run dir with `prompts.jsonl`, finalize a manifest,
      verify that it passes.
    - Mutate `prompts.jsonl` and verify that `ManifestVerifier` reports
      an error and includes `prompts.jsonl` in the issues.
- This ensures prompt provenance is covered by the same integrity guarantees
  as other artifacts.

---

## Behavior

- Default runtime behavior is unchanged:
  - Prompt provenance remains **opt-in** behind
    `prompt_provenance_enabled` and `prompt_provenance_mode`.
  - No change to how manifests are written unless `prompts.jsonl` exists.
- When prompt provenance is enabled and prompts are recorded:
  - `prompts.jsonl` is listed in `manifest.json` as `"kind": "attachment"`.
  - `noesis artifacts verify` will now detect tampering of prompt artifacts.

---

## Testing

```bash
uv run pytest tests/runtime/test_artifacts.py::test_manifest_verifier_detects_prompt_tampering