### PR TITLE
feat(determinism): wire replay CI gate and veto regression

### DIFF
--- a/.github/workflows/determinism-replay.yml
+++ b/.github/workflows/determinism-replay.yml
@@ -1,0 +1,31 @@
+name: Determinism Replay Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  replay-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Run replay gate (golden + veto)
+        run: uv run python scripts/replay_gate.py

--- a/scripts/replay_gate.py
+++ b/scripts/replay_gate.py
@@ -1,0 +1,138 @@
+"""
+Determinism replay gate for CI.
+
+Checks:
+- Minimal-mode golden pair under tests/golden/deterministic_run.
+- Deterministic veto scenario generated on the fly in planner META mode.
+
+Fails with non-zero exit when drift is detected.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from noesis.diagnostics import compare_runs
+from noesis.domain.faculties.intuition import IntuitionMode
+from noesis.domain.learning.model import LearnMode
+from noesis.interfaces.config import ConfigPort, ConfigSnapshot, PlannerMode
+from noesis.runtime.determinism import DeterministicClock, DeterministicRNG
+from noesis.runtime.session import SessionBuilder
+
+
+def _episode_dir(root: Path) -> Path:
+    candidates = sorted(p for p in root.iterdir() if p.is_dir() and p.name.startswith("ep_"))
+    if not candidates:
+        raise FileNotFoundError(f"No episode directories found under {root}")
+    return candidates[0]
+
+
+def _assert_no_drift(label: str, a: Path, b: Path) -> None:
+    result = compare_runs(a, b)
+    if result.is_drift:
+        mismatches = "; ".join(f"{m.artifact}: {m.detail}" for m in result.mismatches)
+        raise SystemExit(f"[{label}] drift detected: {mismatches}")
+    print(f"[{label}] OK (NO_DRIFT)")
+
+
+@dataclass(slots=True)
+class _SnapshotPort(ConfigPort):
+    snapshot: ConfigSnapshot
+
+    def get(self) -> ConfigSnapshot:  # type: ignore[override]
+        return self.snapshot
+
+    def set(self, **overrides: object) -> ConfigSnapshot:  # type: ignore[override]
+        data = self.snapshot.to_mapping()
+        data.update(overrides)
+        self.snapshot = ConfigSnapshot.from_mapping(data)
+        return self.snapshot
+
+    def reload(self) -> ConfigSnapshot:  # type: ignore[override]
+        return self.snapshot
+
+    def supports(self, capability: str) -> bool:  # type: ignore[override]
+        return False
+
+
+def _config_snapshot(root: Path, planner_mode: PlannerMode) -> ConfigSnapshot:
+    learn_home = root / "learn"
+    learn_home.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "runs_dir": str(root),
+        "agents": "agents.toml",
+        "tasks": "tasks.toml",
+        "timeout_sec": 5,
+        "intuition_mode": IntuitionMode.ADVISORY.value,
+        "direction_min_confidence": 0.5,
+        "planner_mode": planner_mode.value,
+        "policy_aliases": {},
+        "learn_mode": LearnMode.OFF.value,
+        "learn_home": str(learn_home),
+        "learn_auto_apply_min_successes": 1,
+        "learn_auto_apply_min_confidence": 0.5,
+        "prompt_provenance_enabled": False,
+        "prompt_provenance_mode": "hash_only",
+    }
+    return ConfigSnapshot.from_mapping(data)
+
+
+def _build_session(root: Path, *, ts_ms: int, seed: int, planner_mode: PlannerMode):
+    clock = DeterministicClock(
+        start_at=datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
+        tick_ms=5.0,
+    )
+    rng = DeterministicRNG(seed=seed)
+    snapshot = _config_snapshot(root, planner_mode)
+    port = _SnapshotPort(snapshot)
+    builder = SessionBuilder(config_port=port).with_determinism(
+        clock=clock,
+        rng=rng,
+        episode_timestamp_ms=ts_ms,
+    )
+    return builder.build()
+
+
+def _check_minimal_golden() -> None:
+    base = Path("tests/golden/deterministic_run")
+    run_a = _episode_dir(base / "run_a")
+    run_b = _episode_dir(base / "run_b")
+    _assert_no_drift("minimal-golden", run_a, run_b)
+
+
+def _check_veto_generated(tmp: Path) -> None:
+    ts_ms = 1_735_700_000_000
+    seed = 999
+    root_a = tmp / "veto_a"
+    root_b = tmp / "veto_b"
+    root_a.mkdir(parents=True, exist_ok=True)
+    root_b.mkdir(parents=True, exist_ok=True)
+
+    session_a = _build_session(root_a, ts_ms=ts_ms, seed=seed, planner_mode=PlannerMode.META)
+    session_b = _build_session(root_b, ts_ms=ts_ms, seed=seed, planner_mode=PlannerMode.META)
+
+    task = "veto this action: delete production database"
+    ep_a = session_a.run(task, intuition=False)
+    ep_b = session_b.run(task, intuition=False)
+
+    _assert_no_drift("veto-generated", root_a / ep_a, root_b / ep_b)
+
+
+def main() -> int:
+    try:
+        _check_minimal_golden()
+        tmp = Path("artifacts/replay_tmp")
+        tmp.mkdir(parents=True, exist_ok=True)
+        _check_veto_generated(tmp)
+    except SystemExit as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements the determinism replay CI gate and tightens governance/session coverage toward the v1.0.0 Definition of Done:

- Adds a script-based replay gate that checks both the stored minimal deterministic goldens and a deterministic veto scenario.
- Wires the replay gate into GitHub Actions so drift becomes CI-blocking.
- Adjusts governance to emit hard vetoes for destructive goals and extends determinism + session tests accordingly.
- Aligns the replay CLI test with the `"NO_DRIFT"` status from diagnostics.

## Changes

### 1. Replay CI gate

- Added `scripts/replay_gate.py`:
  - Loads the existing minimal deterministic golden pair.
  - Generates a META run that triggers a governance veto in a stable way.
  - Uses `noesis.diagnostics.compare_runs` under `DeterminismConfig` to assert NO_DRIFT across core artifacts.
  - Exits with a non-zero status if any drift is detected so CI can treat this as a hard regression.

### 2. GitHub Actions workflow

- Added `.github/workflows/determinism-replay.yml`:
  - Runs on pushes and pull requests.
  - Uses Python 3.12 with `uv` to set up the environment.
  - Invokes the replay gate script so both minimal and veto paths are checked on every change.

### 3. Governance + determinism tests

- Governance:
  - Updated the governance rules to emit hard veto decisions for clearly destructive goals (e.g., destroy/shutdown/wipe), making veto scenarios deterministic and suitable for goldens.
- Tests:
  - Extended determinism tests to cover the veto path alongside the existing minimal deterministic runs.
  - Kept/enhanced `NoesisSession` parallel-run and reuse/no-leak tests so session threading/ownership guarantees are exercised together with replay.
  - Updated the replay CLI test to assert the `"NO_DRIFT"` status emitted by diagnostics.

### 4. Status vs v1.0.0 Definition of Done

- **Done in this PR**
  - Deterministic replay gate (script + workflow) over minimal and veto goldens.
  - Governance veto path made deterministic and covered by tests.
  - Session GA coverage improved via parallel/reuse checks.

- **Still outstanding**
  - Add a real LLM-backed example with a checked-in golden that passes the replay gate.
  - Document the replay gate (local usage, golden refresh process) in the docs.

## Testing

- Local:
  - `uv run pytest tests/diagnostics/test_replay_cli.py -vv`
  - `uv run pytest tests/runtime/test_determinism.py::test_governance_veto_run_is_deterministic -vv`
- CI:
  - `.github/workflows/determinism-replay.yml` runs the replay gate and fails on any drift.