### PR TITLE
refactor(usecases): introduce ports for episode orchestration

### DIFF
--- a/internal_docs/adr/ADR-006-core-runtime-decomposition.md
+++ b/internal_docs/adr/ADR-006-core-runtime-decomposition.md
@@ -1,0 +1,255 @@
+# ADR-006 — Core Runtime Decomposition & Ports for Episode Orchestration
+
+**Status:** In progress  
+**Date:** 2025-12-09  
+**Owner:** Noēsis maintainer (@saraeloop)  
+**Since:** v1.0.0 (post-GA refactor)
+
+⸻
+
+## 1. Context
+
+By v1.0.0, Noēsis has a stable substrate:
+
+- **ADR-001 — Runtime ownership & `NoesisSession`.**  
+  Session-first runtime model, `NoesisSession` / `ns.run/solve`, deterministic entrypoints.
+- **ADR-002 — Artifact immutability & manifest.**  
+  `events.jsonl`, `state.json`, `summary.json`, `manifest.json` with atomic writes + HMAC.
+- **ADR-003 — Schema governance & KPIs.**  
+  Schema versions, field-level stability flags, semver rules, and KPI definitions.
+- **ADR-004 — Determinism substrate.**  
+  `DeterminismConfig`, deterministic clocks/IDs, replay diagnostics and golden runs.
+- **ADR-005 — Prompt provenance v1.1 (experimental).**  
+  Optional `prompts.jsonl` with schema-governed prompt records and privacy modes.
+
+These pieces are stable and tested. However, the core runtime orchestration has accumulated too many responsibilities in a small number of modules:
+
+- **`noesis/core.py`:**
+  - Public entrypoints: `run`, `solve`, `run_using`, `run_graph`, `set`.
+  - Episode orchestration: minting episode IDs, setting up `EpisodeContext`, constructing `RuntimeStateRepository`, `EpisodeRunner`, and the event bus.
+  - Determinism wiring: `DeterminismConfig`, deterministic clocks/IDs, minimal vs META / adapter execution.
+  - Minimal vs adapter paths: `core.minimal` planner/actuator, adapter selection and invocation.
+  - Artifact finalization: `summary.json`, `manifest.json`, episode index.
+- **`noesis/usecases/episode_runner.py`:**
+  - Coordinates planners, actuators, governance (`PreActGovernor`), state repository, and event emission.
+  - Uses concrete types such as `RuntimeStateRepository` and `PromptRecorder` directly.
+
+Architecture review (Clean Architecture lens) highlights some concrete problems:
+
+1. **Application/use-case layer depends on infra concretions.**  
+   `EpisodeDependencies` and `EpisodeRunner` take a concrete `RuntimeStateRepository` and reach into runtime helpers (`read_events`, `PromptRecorder`) instead of abstract ports. This makes the use case layer hard to test in isolation and tightly couples it to the filesystem and prompt recorder implementation.
+
+2. **Core orchestration mixes policy, orchestration, and infrastructure wiring.**  
+   `_run_impl(...)` in `noesis/core.py`:
+   - Loads config, sets up determinism, constructs state repositories and event buses,
+   - Builds planners, actuators, governors,
+   - Branches between minimal vs adapter execution,
+   - Finalizes artifacts and indexes.  
+   This violates single responsibility and makes the core difficult to extend or reason about.
+
+3. **Global runtime context singleton still exists.**  
+   `get_context()` auto-creates a global context and is still used as a default. This undermines ADR-001’s “session owns runtime” principle and is risky under concurrency.
+
+There is also an existing issue describing the need for this refactor:
+
+> **[Feature] refactor(core): split episode orchestration + adapter integration into smaller units (post-1.0.0) #39**
+
+This ADR formalizes what we want the architecture to look like and how we’ll refactor toward it.
+
+⸻
+
+## 2. Decision
+
+We will:
+
+1. **Introduce explicit ports for episode orchestration**  
+   (Clean Architecture: use-case layer depends only on ports, never on infra concretions):
+
+   - Define interfaces/protocols in the application/use-case layer for:
+     - `StateRepositoryPort` (read/write state, list episodes),
+     - `EventSinkPort` / `EventBusPort` (append events, flush),
+     - `PromptRecorderPort` (record prompt provenance where enabled),
+     - `ClockPort` / `IdFactoryPort` (if needed explicitly).
+   - Make `EpisodeRunner` and `EpisodeDependencies` depend on these ports, not on `RuntimeStateRepository`, `PromptRecorder`, or filesystem helpers.
+
+2. **Decompose `noesis.core` into smaller, mode-specific orchestrators**  
+   without changing the public API:
+
+   - Keep public entrypoints (`run`, `solve`, `run_using`, `run_graph`) intact.
+   - Split the internal orchestration into:
+     - `_run_minimal_episode(...)` — for `core.minimal` runs,
+     - `_run_adapter_episode(...)` — for adapter-backed runs.
+   - Extract shared helpers for:
+     - Episode initialization (ID, context, ports construction),
+     - Summary finalization,
+     - Manifest + index finalization,
+     - Determinism wiring (so both paths reuse the same logic).
+
+3. **Constrain global runtime context to legacy shims only**
+
+   - Enforce session-first usage:
+     - New and primary paths require an explicit `NoesisSession` / `RuntimeContext`.
+   - Keep the global `get_context()` only for:
+     - Legacy `noesis.run(...)` / `noesis.solve(...)` convenience,
+     - CLI entrypoints that do not yet pass a session object.
+   - Internally, all new orchestration calls will receive a context/session explicitly; they will not read the global singleton directly.
+
+4. **Preserve all external behavior and artifacts for v1.0.x**
+
+   - No changes to:
+     - Artifact schemas or schema versions,
+     - Replay gates or determinism semantics,
+     - CLI flags or core API signatures.
+   - The refactor must be validated by:
+     - Existing test suite (unit + integration),
+     - Determinism tests (including veto scenarios),
+     - Replay diagnostics (`diagnostics replay`) on golden runs.
+
+This ADR is structural: it does not introduce new features. It reduces coupling, clarifies boundaries, and makes Noēsis safer to extend (for adapters, telemetry, or multi-agent runtimes) without breaking the v1.0.0 contracts.
+
+⸻
+
+## 3. Rationale
+
+### 3.1 Clean Architecture & testability
+
+Today, `EpisodeRunner` cannot be used in a pure unit test without:
+
+- A real `RuntimeStateRepository`,
+- Filesystem access for `events.jsonl` / `state.json`,
+- A concrete `PromptRecorder`.
+
+This violates the Clean Architecture rule: use cases depend on abstractions, not on infrastructure.
+
+By introducing ports:
+
+- We can test the episode orchestration with in-memory or fake implementations.
+- Integrations (LangGraph, CrewAI, Gradient, Bedrock AgentCore, etc.) can supply their own state/event sinks if they want.
+
+### 3.2 Runtime extensibility
+
+Noēsis is not a LangGraph plugin or a CrewAI fork; it’s a cognitive runtime that must:
+
+- Run in CLIs,
+- Export traces into different telemetry systems (LangSmith, OpenTelemetry, homegrown),
+- Work with multiple agent frameworks.
+
+If core orchestration is a big ball of concrete classes, each new integration becomes invasive. With clear ports:
+
+- You can create alternate infra implementations (e.g., `OpenTelemetryEventSink`, `LangSmithStateRepository`) in outer layers,
+- Without touching the episode logic.
+
+### 3.3 Containing global state
+
+ADR-001 says the session owns the runtime. The remaining global context:
+
+- Makes behavior under concurrency harder to reason about,
+- Creates surprising interactions when multiple callers use `noesis.run()` in the same process.
+
+Constraining the singleton to legacy/shim paths moves Noēsis closer to the intended model:
+
+> “A session is the unit of ownership; all state is passed explicitly.”
+
+⸻
+
+## 4. Detailed Design
+
+### 4.1 Ports for episode orchestration
+
+In an application/use-case module (e.g., `noesis/usecases/ports.py`):
+
+```python
+from typing import Protocol, Any, Mapping, Iterable
+
+class StateRepositoryPort(Protocol):
+    def load(self, episode_id: str) -> Mapping[str, Any]: ...
+    def save(self, episode_id: str, state: Mapping[str, Any]) -> None: ...
+    def exists(self, episode_id: str) -> bool: ...
+
+class EventSinkPort(Protocol):
+    def append(self, episode_id: str, event: Mapping[str, Any]) -> None: ...
+    def flush(self, episode_id: str) -> None: ...
+
+class PromptRecorderPort(Protocol):
+    def record(
+        self,
+        *,
+        phase: str,
+        agent_id: str,
+        template_id: str | None,
+        rendered: str | None,
+        variables: Mapping[str, Any] | None,
+        tags: Mapping[str, str] | None,
+    ) -> None: ...
+
+class ClockPort(Protocol):
+    def now(self) -> datetime: ...
+
+class IdFactoryPort(Protocol):
+    def new_event_id(self) -> UUID: ...
+    def new_directive_id(self, episode_id: str) -> UUID: ...
+```
+
+These ports are **domain-shaped**:
+
+- `StateRepositoryPort` operates on domain state (e.g., `NoesisState.to_dict()` payloads), not arbitrary mappings.
+- `EventSinkPort`/`EventBusPort` operate on `CognitiveEvent` payloads (or strongly typed equivalents) and support `flush`.
+- Determinism requires injecting `ClockPort` + `IdFactoryPort`; default impls wrap `DeterministicClock`/`RuntimeClock` and deterministic UUID/ULID factories.
+
+Concrete bindings (outer layer):
+
+- `RuntimeStateRepository` → `StateRepositoryPort`
+- `RuntimeEventBus` + `CognitiveEventEmitter` → `EventSinkPort`/`EventBusPort`
+- `PromptRecorder` → `PromptRecorderPort` (with no-op impl when disabled)
+- `DeterministicClock` / `RuntimeClock` → `ClockPort`
+- `determinism.rng.event_id_factory` / `uuid4` → `IdFactoryPort`
+
+### 4.2 Core decomposition plan
+
+- Keep public API (`run/solve/run_using/run_graph`) stable.
+- Split orchestration internals:
+  - `_run_minimal_episode(...)`
+  - `_run_adapter_episode(...)`
+- Extract factories (outer/runtime layer):
+  - `make_episode_context(cfg, determinism, task, tags, using_label)`
+  - `make_ports(context, determinism)` → returns state repo port, event bus port, prompt recorder port, clock/id factories.
+  - `finalize_summary(...)`, `finalize_manifest_and_index(...)` reused by both paths.
+- Keep adapter selection (`_select_adapter`) in the outer layer; use-case logic should receive an already-wrapped actuator/adapter port.
+
+### 4.3 Prompt provenance handling
+
+- `PromptRecorderPort` is injected; when provenance is disabled, bind a no-op impl.
+- Deterministic mode uses injected `ClockPort`/`IdFactoryPort` for timestamps and IDs; hashing remains deterministic.
+- Ports keep prompt schema compatibility; no schema/version changes in this refactor.
+
+### 4.4 Acceptance criteria (must all hold)
+
+- Behavior: artifacts (`events.jsonl`, `state.json`, `summary.json`, `manifest.json`, optional `prompts.jsonl`) and schema versions are unchanged.
+- Determinism: existing replay tests stay green (byte-stable summaries/manifests; structural event equality).
+- Import-linter: new contracts added to forbid use-case layer importing runtime/infra; CI enforced.
+- Tests: unit and integration suites pass; determinism + veto scenarios pass; schema guard unaffected.
+- Public API: signatures and CLI flags unchanged.
+
+### 4.5 Migration plan
+
+1) Introduce ports module (`noesis/usecases/ports.py`) and no-op prompt recorder.  
+2) Add outer-layer factories to build concrete ports from `SessionConfig` + determinism.  
+3) Refactor `EpisodeRunner` to consume ports (no direct `RuntimeStateRepository`, `PromptRecorder`, `read_events`).  
+4) Split `core` into `_run_minimal_episode` / `_run_adapter_episode` using ports.  
+5) Gate `get_context()` to legacy shims; new paths require explicit session/context.  
+6) Strengthen import-linter/CI and backfill tests for new ports wiring.  
+7) Delete dead code paths once dual support is stable.
+
+### 4.6 Implementation checkpoints
+
+- ✅ Split runtime orchestration into `_run_minimal_episode` and `_run_adapter_episode` with shared finalization helpers; public API preserved.
+- ⏳ Introduce `usecases/ports.py` and migrate `EpisodeRunner` to depend on ports (no direct infra imports).
+- ⏳ Add outer-layer factories to bind ports (`StateRepositoryPort`, `EventBusPort`, `PromptRecorderPort`, `Clock/IdFactory`) from session/determinism.
+- ⏳ Enforce import-linter rules for new boundaries and add fake-based unit tests for orchestrator portability.
+- ⏳ Remove legacy infra coupling once port-based path is the default.
+
+### 4.6 Consequences / risks / timeline
+
+- Pros: cleaner layering, easier testing with in-memory fakes, safer integrations (LangGraph/CrewAI/OTel) without touching core.
+- Risks: temporary churn while both wiring styles coexist; must watch determinism regressions and schema drift.
+- Timeline: target post-GA (v1.0.x) in 2–3 PRs following the migration steps; keep release notes noting “internal refactor, no surface change.”

--- a/noesis/usecases/episode_runner.py
+++ b/noesis/usecases/episode_runner.py
@@ -23,13 +23,27 @@ from noesis.domain.planner.meta import MetaPlanner
 from noesis.domain.faculties.direction import PlannerDirective, DirectiveStatus
 from noesis.domain.faculties.governance import GovernanceDecision, GovernanceResult, PreActGovernor
 from noesis.domain.state import CognitiveEvent, CognitiveMetrics, CognitiveVerb, LineageTracker, NoesisState, PlanKind, PlanStep, OUTCOME_STATUS_VETOED
-from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
+from noesis.infrastructure.state_repository import EpisodeContext
 from noesis.runtime.clock import RuntimeClock
-from noesis.runtime.prompt_recorder import PromptRecorder
 from noesis.runtime.events_emitter import CognitiveEventEmitter
 from noesis.runtime.artifacts.ids import directive_uuid, governance_uuid
 from noesis.trace.events import read_events
 from .hooks.meta_phase import CompositeMetaPhaseHook, MetaPhaseHook, NullMetaPhaseHook
+from .ports import (
+    ClockPort,
+    EventHistoryPort,
+    EventIdFactoryPort,
+    EventSinkPort,
+    PromptRecorderPort,
+    StateRepositoryPort,
+)
+
+
+class _EventHistoryAdapter:
+    """Structural adapter to expose read_events as a port."""
+
+    def read(self, run_dir) -> Sequence[Dict[str, object]]:
+        return read_events(run_dir)
 
 
 @dataclass(slots=True)
@@ -60,18 +74,20 @@ class EpisodeDependencies:
     planner: Planner
     actuator: Actuator
     event_bus: EventBus
-    state_repository: RuntimeStateRepository
+    state_repository: StateRepositoryPort
     direction_planner: MetaPlanner | None = None
     governance_policy: PreActGovernor | None = None
 
 
 @dataclass(slots=True)
 class EpisodeInstrumentation:
-    clock: RuntimeClock
-    emitter: CognitiveEventEmitter
+    clock: ClockPort
+    emitter: EventSinkPort
     lineage: LineageTracker
+    event_history: EventHistoryPort = field(default_factory=_EventHistoryAdapter)
+    prompt_recorder: PromptRecorderPort | None = None
     now: Callable[[], datetime] = field(default_factory=lambda: datetime.now(timezone.utc))
-    event_id_factory: Callable[[], UUID] = uuid4
+    event_id_factory: EventIdFactoryPort | Callable[[], UUID] = uuid4
     rng: object | None = None
     hooks: Sequence[MetaPhaseHook] = field(default_factory=lambda: (NullMetaPhaseHook(),))
 
@@ -94,6 +110,8 @@ class EpisodeRunner:
                 clock=RuntimeClock(),
                 emitter=CognitiveEventEmitter(run_dir=context.run_dir),
                 lineage=LineageTracker(),
+                event_history=_EventHistoryAdapter(),
+                prompt_recorder=getattr(context, "prompt_recorder", None),
                 now=datetime.now,
                 event_id_factory=uuid4,
                 hooks=(NullMetaPhaseHook(),),
@@ -101,13 +119,14 @@ class EpisodeRunner:
         self._clock = instrumentation.clock
         self._emitter = instrumentation.emitter
         self._lineage = instrumentation.lineage
+        self._event_history = instrumentation.event_history
         self._now = instrumentation.now
         factory = instrumentation.event_id_factory
         self._event_id_factory = factory if callable(factory) else (lambda: factory)
         hooks = instrumentation.hooks or (NullMetaPhaseHook(),)
         self._hooks = CompositeMetaPhaseHook(tuple(hooks))
         self._context = context
-        self._prompt_recorder: PromptRecorder | None = getattr(context, "prompt_recorder", None)
+        self._prompt_recorder: PromptRecorderPort | None = instrumentation.prompt_recorder or getattr(context, "prompt_recorder", None)
 
     def run(self, request: EpisodeRequest) -> EpisodeResult:
         context = request.context
@@ -134,7 +153,7 @@ class EpisodeRunner:
         return EpisodeResult(state=state, outcome=outcome, plan=plan)
 
     def _seed_lineage(self, context: EpisodeContext) -> None:
-        events = read_events(context.run_dir)
+        events = self._event_history.read(context.run_dir)
         last_id: UUID | None = None
         for event in reversed(events):
             raw_id = event.get("id")
@@ -465,9 +484,11 @@ class EpisodeRunner:
             now=self._now,
         )
 
-    def _resolve_prompt_recorder(self, context: EpisodeContext) -> PromptRecorder | None:
+    def _resolve_prompt_recorder(self, context: EpisodeContext) -> PromptRecorderPort | None:
         recorder = getattr(context, "prompt_recorder", None) or self._prompt_recorder
-        if recorder is None or not recorder.is_enabled():
+        if recorder is None:
+            return None
+        if not hasattr(recorder, "is_enabled") or not recorder.is_enabled():  # type: ignore[attr-defined]
             return None
         return recorder
 

--- a/noesis/usecases/ports.py
+++ b/noesis/usecases/ports.py
@@ -1,0 +1,101 @@
+"""
+Ports for episode orchestration (Clean Architecture boundary).
+
+These abstractions allow the use-case layer to remain decoupled from
+filesystem-bound implementations. Infrastructure adapters must satisfy
+these protocols; structural typing keeps existing runtime classes compatible.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
+from uuid import UUID
+
+from noesis.domain.state import CognitiveEvent, NoesisState
+
+
+class StateRepositoryPort(Protocol):
+    """State persistence boundary."""
+
+    context: Any
+
+    def init(self, request: Any | None = None) -> NoesisState:
+        ...
+
+    def persist(self, state: NoesisState) -> None:
+        ...
+
+
+class EventSinkPort(Protocol):
+    """Event emission boundary."""
+
+    def emit(self, event: CognitiveEvent, agent_id: str = "system") -> None:
+        ...
+
+
+class EventHistoryPort(Protocol):
+    """Historical event access (used to seed lineage)."""
+
+    def read(self, run_dir: Path) -> Sequence[Mapping[str, Any]]:
+        ...
+
+
+class PromptRecorderPort(Protocol):
+    """Prompt provenance boundary."""
+
+    def is_enabled(self) -> bool:
+        ...
+
+    def record(
+        self,
+        *,
+        phase: str,
+        agent_id: str,
+        rendered: str,
+        role: str | None = None,
+        kind: str | None = None,
+        model: str | None = None,
+        template_id: str | None = None,
+        template: str | None = None,
+        variables: Mapping[str, object] | None = None,
+        tags: Mapping[str, str] | None = None,
+        event_id: str | None = None,
+        outcome_event_id: str | None = None,
+        timestamp: str | None = None,
+        now: Any | None = None,
+    ) -> None:
+        ...
+
+
+class ClockPort(Protocol):
+    """Clock used for phase timing."""
+
+    def start(self, label: Any) -> Any:
+        ...
+
+    def stop(self, token: Any) -> Any:
+        ...
+
+    def now(self) -> datetime:
+        ...
+
+
+class EventIdFactoryPort(Protocol):
+    """Factory for deterministic event IDs."""
+
+    def __call__(self) -> UUID:
+        ...
+
+
+@dataclass(slots=True)
+class EpisodeInstrumentationPorts:
+    clock: ClockPort
+    emitter: EventSinkPort
+    event_history: EventHistoryPort
+    prompt_recorder: PromptRecorderPort | None
+    now: Any
+    event_id_factory: EventIdFactoryPort
+    hooks: Any
+    lineage: Any


### PR DESCRIPTION
### Summary

This PR implements the first concrete steps of **ADR-006 — Core Runtime
Decomposition & Ports for Episode Orchestration** by introducing explicit ports
for episode orchestration and refactoring the `EpisodeRunner` to depend on them.

The goal is to decouple the use-case layer from filesystem-bound infrastructure
while preserving existing behavior, determinism, and artifacts.

### What changed

- **New ports module**

  - Added `noesis/usecases/ports.py` with Clean Architecture ports:

    - `StateRepositoryPort` — boundary for state persistence.
    - `EventSinkPort` — boundary for emitting `CognitiveEvent`s.
    - `EventHistoryPort` — boundary for reading past events (used to seed
      lineage).
    - `PromptRecorderPort` — boundary for prompt provenance recording.
    - `ClockPort` — abstraction over runtime/deterministic clocks.
    - `EventIdFactoryPort` — abstraction over event ID generation.
    - `EpisodeInstrumentationPorts` — small bundle to group instrumentation
      ports (clock, emitter, event_history, prompt_recorder, event_id_factory,
      lineage, hooks).

  - Ports are intentionally protocol-based so existing runtime classes can
    satisfy them via **structural typing**, keeping current wiring compatible.

- **Episode runner refactor**

  - Updated `noesis/usecases/episode_runner.py` to depend on ports instead of
    concrete infra types:

    - `EpisodeRequest.state_repository` now uses `StateRepositoryPort` instead
      of `RuntimeStateRepository`.

    - `EpisodeInstrumentation` now carries:

      - `clock: ClockPort`
      - `emitter: EventSinkPort`
      - `event_history: EventHistoryPort` (with a default)
      - `prompt_recorder: PromptRecorderPort | None`
      - `event_id_factory: EventIdFactoryPort | Callable[[], UUID]`
      - `lineage` and `hooks` as before

    - Introduced a structural `_EventHistoryAdapter` that wraps
      `read_events(run_dir)` so existing code paths can still seed lineage from
      `events.jsonl` without changing call sites.

    - `_seed_lineage(...)` now uses `EventHistoryPort.read(...)` instead of
      calling `read_events` directly.

    - `_resolve_prompt_recorder(...)` now works with `PromptRecorderPort`:
      it returns `None` if no recorder is present, and safely checks for
      `is_enabled()` when supported.

- **Behavior / compatibility**

  - No changes to artifact shapes or determinism semantics.
  - Existing runtime wiring continues to function via structural typing: current
    `RuntimeStateRepository`, `CognitiveEventEmitter`, and `PromptRecorder`
    satisfy the new Protocols without additional glue.
  - This PR is intentionally limited to the use-case layer; wiring of concrete
    ports from the runtime/infra layer will follow in subsequent ADR-006 steps.

### Why this is useful

- Moves the project closer to ADR-006’s Clean Architecture goals:
  - Use cases depend on **ports**, not infrastructure.
  - Episode orchestration becomes easier to test with in-memory fakes.
  - Future integrations (e.g., alternate event sinks, telemetry backends)
    can plug in at the edges without modifying `EpisodeRunner`.

- Sets up later work:
  - Runtime-side factories to build `EpisodeInstrumentationPorts` from config
    + determinism.
  - Tighter import-linter rules preventing `noesis.usecases` from importing
    runtime/infra directly.

### Verification

- `uv run pytest`
- `uv run lint-imports`

All tests and existing import-linter contracts are green.