### PR TITLE
docs(reference): align v1.0.0 docs with CLI + governance behavior

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,17 +16,16 @@ Before running commands, set any LLM adapter or model provider environment varia
 
 ## Installation
 
-If you're trying Noēsis while it's still pre-release, start with **From source (preferred)**.
+The PyPI release is pending. For now, install from source:
 
 <Tabs>
-  <Tab title="From source (preferred)">
+  <Tab title="From source (recommended)">
     ```bash
     git clone https://github.com/saraeloop/noesis.git
     cd noesis
     uv tool install .
     # or: pipx install .
     ```
-    <Tip>Source-first is recommended while the PyPI release is pending.</Tip>
   </Tab>
   <Tab title="uv (when PyPI is live)">
     ```bash

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -11,7 +11,7 @@ The CLI surface is intentionally small in this release. A more robust CLI is in 
 
 ## Installation
 
-Install from source while the PyPI name is pending:
+Install from source while the PyPI release is pending:
 
 ```bash
 git clone https://github.com/saraeloop/noesis.git
@@ -20,7 +20,7 @@ uv tool install .
 # or: pipx install .
 ```
 
-When the PyPI release is live, you can also use `uv add noesis` or `pip install noesis`.
+When PyPI is live, use `uv add noesis` or `pip install noesis`.
 
 ## Commands
 
@@ -150,6 +150,14 @@ noesis list -j | jq '.[0].episode_id'
 | Task | Truncated task description |
 | Manifest | Status note (only when `--strict-manifest` is used) |
 
+**Example output**:
+
+```
+Started              ID                      Task
+2024-12-27 10:15:32  ep_2024_abc123_s0       Draft release notes
+2024-12-27 09:45:11  ep_2024_def456_s0       Analyze logs
+```
+
 ### noesis show
 
 Display episode summary.
@@ -179,6 +187,16 @@ noesis show ep_2024_abc123_s0
 
 # Raw JSON
 noesis show ep_2024_abc123_s0 -j
+```
+
+**Example output**:
+
+```
+Episode: ep_2024_abc123_s0
+Task: Draft release notes
+Status: success
+Started: 2024-12-27T10:15:32Z
+Duration: 1.23s
 ```
 
 ### noesis view
@@ -215,6 +233,25 @@ noesis view ep_2024_abc123_s0
 
 # JSON
 noesis view ep_2024_abc123_s0 -j | jq '.summary.metrics.success'
+
+# Show artifact paths
+noesis view ep_2024_abc123_s0 --open
+```
+
+**Example output** (with `--open`):
+
+```
+=== artifacts ===
+dir: runs/ep_2024_abc123_s0
+summary: runs/ep_2024_abc123_s0/summary.json
+events: runs/ep_2024_abc123_s0/events.jsonl
+
+=== timeline ===
+[start] 2024-12-27T10:15:32.000Z
+[observe] input captured
+[plan] 3 steps planned
+[act] executed
+[reflect] success
 ```
 
 ### noesis events
@@ -276,6 +313,19 @@ noesis events $(noesis list -j | jq -r '.[0].episode_id')
 | `terminate` | End state |
 | `error` | Error events |
 
+**Example output**:
+
+```
+Episode: ep_2024_abc123_s0
+[start] 2024-12-27T10:15:32.000Z
+[observe] input captured
+[interpret] signals extracted
+[plan] 3 steps planned
+[act] step 1 executed
+[reflect] success
+[terminate] episode complete
+```
+
 ### noesis insight
 
 Show computed insight events (alias for `events --phase insight`).
@@ -326,8 +376,12 @@ noesis artifacts verify TARGET [options]
 | Option | Description | Default |
 | --- | --- | --- |
 | `--strict` | Fail when unexpected files are present | False |
-| `-j, --json` | Emit JSON report | False |
+| `--json` | Emit JSON report | False |
 | `-q, --quiet` | Suppress human-readable output | False |
+
+<Note>
+Unlike most commands, `artifacts verify` uses `--json` without a `-j` short form.
+</Note>
 
 **Exit codes**:
 
@@ -342,6 +396,22 @@ noesis artifacts verify TARGET [options]
 
 ```bash
 noesis artifacts verify ep_2024_abc123_s0 --strict
+```
+
+**Example output**:
+
+```
+=== Artifact verification ===
+manifest : runs/ep_2024_abc123_s0/manifest.json
+status   : ok
+files    : 4
+duration : 12.34 ms
+issues   : none
+files detail:
+  - summary.json: ok
+  - events.jsonl: ok
+  - state.json: ok
+  - manifest.json: ok
 ```
 
 ### noesis diagnostics
@@ -365,7 +435,19 @@ noesis diagnostics replay RUN_A RUN_B [options]
 | `-j, --json` | Emit JSON payload | False |
 | `-q, --quiet` | Suppress human-readable output | False |
 
-Checks include runs_dir health, learn_home, confidence bounds, learn thresholds, registered ports, config snapshot drift, latest summary schema, and latest manifest verification.
+**Available checks**:
+
+| Check name | What it validates |
+| --- | --- |
+| `runs_dir` | Directory exists, is writable, has free space |
+| `learn_home` | Directory exists and is valid |
+| `direction_min_confidence` | Value within [0, 1] |
+| `learn_auto_apply_min_confidence` | Value within [0, 1] |
+| `learn_auto_apply_min_successes` | Value >= 1 |
+| `ports` | Registered ports have valid API version format |
+| `config_snapshot` | Runtime config matches current snapshot |
+| `latest_summary` | Most recent summary schema version is current |
+| `artifact_manifest` | Most recent manifest passes verification |
 
 **Replay mode options**:
 
@@ -381,11 +463,36 @@ Checks include runs_dir health, learn_home, confidence bounds, learn thresholds,
 # Default diagnostics
 noesis diagnostics --strict
 
+# Run specific checks only
+noesis diagnostics --checks runs_dir,ports,artifact_manifest
+
 # Drift compare two runs
 noesis diagnostics replay runs/ep_a runs/ep_b
 ```
 
 Replay exits `1` on drift, `0` otherwise. Default mode exits `1` on errors (or warnings when `--strict`).
+
+**Example output** (default mode):
+
+```
+=== Noēsis diagnostics ===
+timestamp             : 1735312532
+version               : 1.0.0
+summary_schema_version: 1.1.0
+state_version         : 1 (schema 1.0)
+selected_checks       : all
+checks:
+  [ok] runs_dir - ./runs
+  [ok] learn_home - ~/.noesis/state
+  [ok] direction_min_confidence - 0.50
+  [ok] learn_auto_apply_min_confidence - 0.75
+  [ok] learn_auto_apply_min_successes - 3
+  [ok] ports - config=config/1.0-rc1
+  [ok] config_snapshot - in sync
+  [ok] latest_summary - runs/ep_2024_abc123_s0/summary.json
+  [ok] artifact_manifest - runs/ep_2024_abc123_s0/manifest.json
+overall status        : ok
+```
 
 ### noesis version
 
@@ -400,6 +507,12 @@ noesis version [-j]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-j, --json` | Emit JSON payload | False |
+
+**Example output**:
+
+```
+Noesis 1.0.0 (core 1.0.0, adapters: langgraph@on, crewai@missing, assistants@missing)
+```
 
 ### noesis validate-ports
 
@@ -469,6 +582,9 @@ These options work with all commands:
 | `NOESIS_RUNS_DIR` | Default runs directory |
 | `NOESIS_PLANNER` | Default planner mode (`meta`/`minimal`) |
 | `NOESIS_DIRECTION_MIN_CONFIDENCE` | Default `direction_min_confidence` |
+| `NOESIS_GOVERNANCE_MODE` | Governance mode (`off`/`audit`/`enforce`) |
+| `NOESIS_GOVERNANCE_FAILURE_POLICY` | Failure policy (`fail_open`/`fail_closed`) |
+| `NOESIS_GOVERNANCE_TIMEOUT_MS` | Governance timeout in milliseconds |
 | `NOESIS_INTUITION_MODE` | Default intuition mode |
 | `NOESIS_TIMEOUT_SEC` | Default timeout |
 | `NOESIS_LEARN_HOME` | Default learn directory |

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -29,7 +29,7 @@ Directory where artifacts are stored.
 
 ### planner_mode
 
-Controls the level of governance and observability.
+Controls planning strategy and direction behavior.
 
 | Source | Setting |
 | --- | --- |
@@ -42,8 +42,34 @@ Controls the level of governance and observability.
 
 | Value | Description |
 | --- | --- |
-| `meta` | Full governance with MetaPlanner and PreActGovernor |
-| `minimal` | Skip governance, use legacy stepwise planner |
+| `meta` | MetaPlanner-enabled planning (direction search / directives) |
+| `minimal` | Minimal planning; skips direction search and runs a simple planner |
+
+<Info>
+`planner_mode` controls planning strategy. Governance is controlled separately via `governance_mode` and `governance_failure_policy`.
+</Info>
+
+### agents
+
+Path to the agents registry file. Used by the CLI to resolve named agents from a registry file. If unset, Noēsis looks for `agents.yaml` in the working directory.
+
+| Source | Setting |
+| --- | --- |
+| Python | `ns.set(agents="agents.yaml")` |
+| Environment | `NOESIS_AGENTS=agents.yaml` |
+| TOML | `agents = "agents.yaml"` |
+| Default | `"agents.yaml"` |
+
+### tasks
+
+Path to the tasks registry file. Used by the CLI to resolve named tasks from a registry file. If unset, Noēsis looks for `tasks.yaml` in the working directory.
+
+| Source | Setting |
+| --- | --- |
+| Python | `ns.set(tasks="tasks.yaml")` |
+| Environment | `NOESIS_TASKS=tasks.yaml` |
+| TOML | `tasks = "tasks.yaml"` |
+| Default | `"tasks.yaml"` |
 
 ### timeout_sec
 
@@ -127,6 +153,43 @@ Minimum confidence threshold for applying plan directives.
 | TOML | `direction_min_confidence = 0.8` |
 | Default | `0.5` |
 
+### governance_mode
+
+Controls pre-act governance behavior.
+
+| Source | Setting |
+| --- | --- |
+| Python | `ns.set(governance_mode="enforce")` |
+| Environment | `NOESIS_GOVERNANCE_MODE=enforce` |
+| TOML | `governance_mode = "enforce"` |
+| Default | `"off"` |
+
+**Values**:
+
+| Value | Description |
+| --- | --- |
+| `off` | Governance disabled |
+| `audit` | Record decisions; never blocks execution |
+| `enforce` | Veto terminates the episode before Act |
+
+### governance_failure_policy
+
+How to handle governance errors/timeouts.
+
+| Source | Setting |
+| --- | --- |
+| Python | `ns.set(governance_failure_policy="fail_closed")` |
+| Environment | `NOESIS_GOVERNANCE_FAILURE_POLICY=fail_closed` |
+| TOML | `governance_failure_policy = "fail_closed"` |
+| Default | Depends on mode (audit→fail_open, enforce→fail_closed) |
+
+**Values**:
+
+| Value | Description |
+| --- | --- |
+| `fail_open` | On error, allow action to proceed |
+| `fail_closed` | On error, treat as veto |
+
 ### learn_home
 
 Directory for learning data storage.
@@ -138,9 +201,9 @@ Directory for learning data storage.
 | TOML | `learn_home = "./learn"` |
 | Default | `~/.noesis/state` |
 
-### prompt_provenance
+### prompt_provenance_enabled
 
-Control prompt provenance logging.
+Enable prompt provenance logging.
 
 | Source | Setting |
 | --- | --- |
@@ -148,6 +211,8 @@ Control prompt provenance logging.
 | Environment | `NOESIS_PROMPT_PROVENANCE_ENABLED=true` |
 | TOML | `prompt_provenance_enabled = true` |
 | Default | `false` |
+
+### prompt_provenance_mode
 
 Mode for prompt provenance storage.
 
@@ -158,18 +223,34 @@ Mode for prompt provenance storage.
 | TOML | `prompt_provenance_mode = "hash_only"` |
 | Default | `"hash_only"` |
 
+**Values**:
+
+| Value | Description |
+| --- | --- |
+| `full` | Store full prompt content |
+| `hash_only` | Store only content hashes (default) |
+| `redacted` | Store redacted content |
+
+<Warning>
+`prompt_provenance_mode="full"` may record prompt content. Use `hash_only` or `redacted` for sensitive environments.
+</Warning>
+
 ## Configuration file
 
-Create a `noesis.toml` in your project root:
+Create a `noesis.toml` in your project root. Noēsis reads configuration from the `[noesis]` table:
 
 ```toml noesis.toml
 [noesis]
 runs_dir = "./runs"
+agents = "agents.yaml"
+tasks = "tasks.yaml"
 planner_mode = "meta"
 learn_mode = "record"
 learn_home = "./learn"
 intuition_mode = "advisory"
 direction_min_confidence = 0.7
+governance_mode = "off"
+governance_failure_policy = "fail_open"
 learn_auto_apply_min_confidence = 0.85
 learn_auto_apply_min_successes = 3
 prompt_provenance_enabled = false
@@ -191,6 +272,8 @@ All configuration options have environment variable equivalents:
 | `learn_home` | `NOESIS_LEARN_HOME` |
 | `intuition_mode` | `NOESIS_INTUITION_MODE` |
 | `direction_min_confidence` | `NOESIS_DIRECTION_MIN_CONFIDENCE` |
+| `governance_mode` | `NOESIS_GOVERNANCE_MODE` |
+| `governance_failure_policy` | `NOESIS_GOVERNANCE_FAILURE_POLICY` |
 | `learn_auto_apply_min_confidence` | `NOESIS_LEARN_AUTO_APPLY_MIN_CONFIDENCE` |
 | `learn_auto_apply_min_successes` | `NOESIS_LEARN_AUTO_APPLY_MIN_SUCCESSES` |
 | `prompt_provenance_enabled` | `NOESIS_PROMPT_PROVENANCE_ENABLED` |
@@ -203,6 +286,8 @@ All configuration options have environment variable equivalents:
 export NOESIS_PLANNER=meta
 export NOESIS_RUNS_DIR=./artifacts
 export NOESIS_DIRECTION_MIN_CONFIDENCE=0.8
+export NOESIS_AGENTS=agents.yaml
+export NOESIS_TASKS=tasks.yaml
 
 # Or inline
 NOESIS_PLANNER=minimal NOESIS_RUNS_DIR=./artifacts noesis run "quick test"
@@ -251,6 +336,7 @@ ns.set(
     runs_dir="./runs",
     planner_mode="meta",
     direction_min_confidence=0.5,
+    governance_mode="off",
     learn_mode="record",
     learn_auto_apply_min_confidence=0.75,
     learn_auto_apply_min_successes=3,
@@ -259,9 +345,9 @@ ns.set(
 )
 ```
 
-## Per-episode overrides
+## Per-episode parameters
 
-Some options can be overridden per episode:
+Some parameters can be set per episode at call time:
 
 ```python
 import noesis as ns
@@ -269,17 +355,22 @@ import noesis as ns
 # Global config
 ns.set(planner_mode="meta")
 
-# Override for specific episode
+# Per-episode parameters
 episode_id = ns.run(
     "quick test",
-    tags={"override": "true"},
-    seed=42,  # per-call seed for reproducibility
+    seed=42,                        # reproducibility seed
+    tags={"env": "staging"},        # metadata tags
+    intuition=True,                 # enable/disable intuition
 )
 ```
 
+<Info>
+Global configuration (via `ns.set()`) applies to all episodes. Per-call parameters like `seed`, `tags`, and `intuition` are set at run time.
+</Info>
+
 ## CLI configuration
 
-Configure the CLI via environment variables (the CLI does not expose `--runs-dir` or `--planner` flags):
+Most CLI configuration is done via environment variables:
 
 ```bash
 NOESIS_RUNS_DIR=./artifacts noesis run "task"
@@ -324,6 +415,7 @@ except ValueError as e:
 runs_dir = "./runs"
 planner_mode = "minimal"
 direction_min_confidence = 0.5
+governance_mode = "off"
 prompt_provenance_enabled = false
 ```
 
@@ -335,6 +427,7 @@ runs_dir = "./runs"
 planner_mode = "meta"
 learn_mode = "record"
 direction_min_confidence = 0.5
+governance_mode = "audit"
 prompt_provenance_enabled = false
 ```
 
@@ -345,6 +438,8 @@ prompt_provenance_enabled = false
 runs_dir = "/var/noesis/runs"
 planner_mode = "meta"
 learn_mode = "record"
+governance_mode = "enforce"
+governance_failure_policy = "fail_closed"
 learn_auto_apply_min_confidence = 0.95
 learn_auto_apply_min_successes = 5
 prompt_provenance_enabled = true

--- a/docs/reference/python-api.mdx
+++ b/docs/reference/python-api.mdx
@@ -3,7 +3,7 @@ title: "Python API"
 description: "Complete reference for the Noēsis Python package."
 ---
 
-Install from source while the PyPI name is pending:
+Install from source while the PyPI release is pending:
 
 ```bash
 git clone https://github.com/saraeloop/noesis.git
@@ -12,7 +12,7 @@ uv tool install .
 # or: pipx install .
 ```
 
-When the PyPI release is live, you can use `uv add noesis` or `pip install noesis`. Import as `import noesis as ns`.
+When PyPI is live, use `uv add noesis` or `pip install noesis`. Import as `import noesis as ns`.
 
 ## Core functions
 
@@ -164,7 +164,7 @@ ns.set(runs_dir="./runs/demo", planner_mode="minimal", direction_min_confidence=
 config = ns.get()  # returns a mapping of current config values
 ```
 
-Common keys: `runs_dir`, `planner_mode` (`meta`/`minimal`), `direction_min_confidence`, `learn_home`, `learn_mode`, `learn_auto_apply_min_confidence`, `learn_auto_apply_min_successes`, `intuition_mode`, `timeout_sec`, `prompt_provenance_enabled`, `prompt_provenance_mode`, `agents`, `tasks`.
+Common keys: `runs_dir`, `planner_mode` (`meta`/`minimal`), `direction_min_confidence`, `governance_mode` (`off`/`audit`/`enforce`), `governance_failure_policy`, `learn_home`, `learn_mode`, `learn_auto_apply_min_confidence`, `learn_auto_apply_min_successes`, `intuition_mode`, `timeout_sec`, `prompt_provenance_enabled`, `prompt_provenance_mode`, `agents`, `tasks`.
 
 ## Intuition and policies
 
@@ -212,6 +212,81 @@ except NoesisVeto as e:
     print(f"Vetoed: {e}")
 ```
 
+## Governance
+
+Pre-act governance evaluates proposed actions before execution. Configure via `ns.set(governance_mode=...)`.
+
+### GovernanceMode
+
+```python
+from noesis.governance import GovernanceMode
+
+GovernanceMode.OFF      # Governance disabled (default)
+GovernanceMode.AUDIT    # Record decisions; never blocks execution
+GovernanceMode.ENFORCE  # Veto terminates the episode before Act
+```
+
+### GovernanceFailurePolicy
+
+```python
+from noesis.governance import GovernanceFailurePolicy
+
+GovernanceFailurePolicy.FAIL_OPEN    # On error, allow action
+GovernanceFailurePolicy.FAIL_CLOSED  # On error, treat as veto
+```
+
+Default depends on mode: `audit` → `fail_open`, `enforce` → `fail_closed`.
+
+### GovernanceDecision
+
+```python
+from noesis.governance import GovernanceDecision
+
+GovernanceDecision.ALLOW  # Action proceeds
+GovernanceDecision.AUDIT  # Action proceeds, flagged for review
+GovernanceDecision.VETO   # Action blocked
+```
+
+### GovernanceResult
+
+Immutable result from governance evaluation.
+
+```python
+from noesis.governance import GovernanceResult
+
+# Fields: decision, rule_id, score, message, policy_id, policy_version,
+#         policy_kind, mode, failure_policy, enforced, error, details
+```
+
+### Custom governors
+
+```python
+from noesis.governance import PreActGovernor, GovernanceResult, GovernanceDecision
+
+class MyGovernor(PreActGovernor):
+    def evaluate(self, *, goal: str, plan) -> GovernanceResult:
+        if "dangerous" in goal.lower():
+            return GovernanceResult(
+                decision=GovernanceDecision.VETO,
+                rule_id="custom.veto.dangerous",
+                score=0.95,
+                message="Blocked by custom policy",
+                policy_id="my_governor",
+                policy_version="1.0.0",
+            )
+        return GovernanceResult(
+            decision=GovernanceDecision.ALLOW,
+            rule_id="custom.allow.default",
+            score=0.1,
+            message="",
+            policy_id="my_governor",
+            policy_version="1.0.0",
+        )
+
+# Pass to ns.run()
+ns.run(task="...", governance_policy=MyGovernor())
+```
+
 ## Session management
 
 Use sessions when you need isolated configuration, explicit lifecycle control, or registered ports.
@@ -232,7 +307,66 @@ with session:
 - `ns.summary.read(episode_id, context=None)`: read `summary.json`.
 - `ns.events.read(episode_id, stream=False, context=None)`: iterate events; pass `stream=True` to lazily consume.
 - `ns.context`: helpers for building runtime contexts and attaching ports (advanced use — see the “Add a memory port” guide).
-- `ns.learn.emit(...)`: advanced learning signal emission (see `noesis.learn`; patterns live in guides such as export metrics/learning signals).
+- `ns.learn`: learning signal emission and proposal management (see Learning section below).
+
+## Learning
+
+The learning subsystem records proposals from episode outcomes for policy improvement.
+
+### LearnMode
+
+```python
+from noesis.learn import LearnMode
+
+LearnMode.OFF     # Disable learning
+LearnMode.RECORD  # Record proposals only (default)
+LearnMode.APPLY   # Auto-apply approved proposals
+```
+
+Configure via `ns.set(learn_mode="record")`.
+
+### LearnStatus
+
+```python
+from noesis.learn import LearnStatus
+
+LearnStatus.PENDING   # Awaiting review
+LearnStatus.APPROVED  # Approved for application
+LearnStatus.REJECTED  # Rejected
+LearnStatus.APPLIED   # Already applied
+```
+
+### LearnProposal
+
+Dataclass for learning signals. Contains `kind`, `payload`, `confidence`, `status`, and metadata.
+
+### ns.learn.emit()
+
+Emit a learning signal for an episode:
+
+```python
+import noesis as ns
+
+ns.learn.emit(
+    episode_id=ep,
+    kind="policy_update",
+    payload={"rule": "block_dangerous", "confidence": 0.9},
+    run_dir=ns.get()["runs_dir"],
+)
+```
+
+### Helper functions
+
+```python
+from noesis.learn import (
+    build_learn_payload,      # Build structured learn payloads
+    persist_episode_learning, # Write learn.jsonl
+    load_policy_snapshot,     # Read current policy state
+    update_policy_snapshot,   # Update policy state
+    derive_target_key,        # Compute target key from proposal
+    summarise_learn_kinds,    # Summarize proposal kinds
+)
+```
 
 ## Episode index
 
@@ -263,6 +397,24 @@ store = EpisodeIndex(
 
 Returned by policy methods. See schema above for fields.
 
+## Determinism utilities
+
+For reproducible testing and replay, Noesis exports deterministic clock and RNG utilities:
+
+```python
+from noesis import DeterministicClock, DeterministicRNG
+
+# Fixed-time clock for testing
+clock = DeterministicClock(start_iso="2025-01-01T00:00:00Z")
+now = clock.now()  # Always returns the same timestamp
+
+# Seeded RNG for reproducibility
+rng = DeterministicRNG(seed=42)
+value = rng.random()  # Deterministic random values
+```
+
+These are used internally by the replay gate to ensure artifact determinism. Exposed for custom test harnesses and advanced integrations.
+
 ## Environment variables
 
 | Variable | Description |
@@ -270,6 +422,8 @@ Returned by policy methods. See schema above for fields.
 | `NOESIS_RUNS_DIR` | Artifact storage directory |
 | `NOESIS_PLANNER` | Planner mode (`meta`/`minimal`) |
 | `NOESIS_DIRECTION_MIN_CONFIDENCE` | Direction minimum confidence |
+| `NOESIS_GOVERNANCE_MODE` | Governance mode (`off`/`audit`/`enforce`) |
+| `NOESIS_GOVERNANCE_FAILURE_POLICY` | Failure policy (`fail_open`/`fail_closed`) |
 | `NOESIS_INTUITION_MODE` | Intuition mode |
 | `NOESIS_TIMEOUT_SEC` | Default timeout (seconds) |
 | `NOESIS_LEARN_HOME` | Learning artifacts directory |


### PR DESCRIPTION
## Summary
This PR performs a full v1.0.0 documentation audit and updates the reference docs to match the current codebase and CLI behavior.

## Changes
- **configuration.mdx**
  - Clarified `planner_mode` vs `governance_mode` / `governance_failure_policy`
  - Added `agents` and `tasks` config options (CLI registry files)
  - Split prompt provenance flags into explicit options
  - Documented that `noesis.toml` reads from the `[noesis]` table
  - Standardized governance mode semantics (`off` / `audit` / `enforce`)
- **python-api.mdx**
  - Added **Governance**, **Learning**, and **Determinism utilities** sections
  - Updated governance descriptions to match v1.0.0 runtime behavior
- **cli.mdx**
  - Documented `artifacts verify --json` (no `-j`)
  - Added `NOESIS_GOVERNANCE_TIMEOUT_MS`
  - Expanded diagnostics check descriptions + included example outputs for major commands
- **quickstart.mdx**
  - Kept PyPI-pending wording since release is still on hold

## Verification
- `uv run pytest` (155 passed)
- Manual CLI spot checks:
  - `noesis --help`
  - `noesis diagnostics --strict`
  - `noesis artifacts verify <episode_id> --strict`