### PR TITLE
fix(artifacts): enforce correctness invariants + Design A learn + schema-b…

### DIFF
--- a/docs/schema/event/1.2.0.json
+++ b/docs/schema/event/1.2.0.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema_name": "event",
+  "$schema_version": "1.2.0",
+  "title": "Noesis event record",
+  "description": "Canonical schema for a single line in events.jsonl.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "timestamp",
+    "episode_id",
+    "phase",
+    "payload",
+    "evidence_ids"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "episode_id": { "type": "string" },
+    "agent_id": { "type": "string" },
+    "phase": { "type": "string" },
+    "faculty": {
+      "type": "string",
+      "enum": ["intuition", "direction", "governance", "insight"]
+    },
+    "payload": { "type": "object" },
+    "evidence_ids": { "type": "array", "items": { "type": "string" } },
+    "caused_by": { "type": "string" },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["started_at", "completed_at", "duration_ms"],
+      "properties": {
+        "started_at": { "type": "string", "format": "date-time" },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "duration_ms": { "type": "number", "minimum": 0 }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "phase": { "const": "learn" }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Design A learn reference payload (learn.jsonl pointer).",
+                "required": ["learn_path", "learn_schema", "proposal_count", "proposal_ids"],
+                "properties": {
+                  "learn_path": { "type": "string" },
+                  "learn_schema": { "type": "string" },
+                  "proposal_count": { "type": "integer", "minimum": 0 },
+                  "proposal_ids": { "type": "array", "items": { "type": "string" } },
+                  "applied": { "type": "boolean" },
+                  "applied_count": { "type": "integer", "minimum": 0 }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Legacy learn payload (inline proposal data).",
+                "required": ["policy_id", "basis", "proposal", "scope"],
+                "properties": {
+                  "policy_id": { "type": "string" },
+                  "basis": { "type": ["object", "array", "string"] },
+                  "proposal": { "type": "array" },
+                  "scope": { "type": "string" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/schema/learn/1.0.0.json
+++ b/docs/schema/learn/1.0.0.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema_name": "learn",
+  "$schema_version": "1.0.0",
+  "title": "Noesis learn record",
+  "description": "Schema for a single line in learn.jsonl.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "id",
+    "episode_id",
+    "agent_id",
+    "timestamp",
+    "payload"
+  ],
+  "properties": {
+    "schema_version": { "const": "learn/1.0" },
+    "id": { "type": "string" },
+    "episode_id": { "type": "string" },
+    "agent_id": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "payload": { "type": "object" }
+  }
+}

--- a/docs/schema/manifest/1.0.0.json
+++ b/docs/schema/manifest/1.0.0.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema_name": "manifest",
+  "$schema_version": "1.0.0",
+  "title": "Noesis manifest artifact",
+  "description": "Schema for manifest.json artifacts.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "episode_id", "files"],
+  "properties": {
+    "schema_version": { "const": "manifest/1.0" },
+    "episode_id": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name", "sha256", "size_bytes", "kind"],
+        "properties": {
+          "name": { "type": "string" },
+          "sha256": { "type": "string" },
+          "size_bytes": { "type": "integer", "minimum": 0 },
+          "kind": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/summary/1.2.0.json
+++ b/docs/schema/summary/1.2.0.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema_name": "summary",
+  "$schema_version": "1.2.0",
+  "title": "Noesis summary artifact",
+  "description": "Canonical schema for summary.json.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "episode_id",
+    "task",
+    "started_at",
+    "metrics"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.2.0" },
+    "episode_id": { "type": "string" },
+    "task": { "type": "string" },
+    "started_at": { "type": "string", "format": "date-time" },
+    "metrics": { "type": "object" }
+  }
+}

--- a/examples/noesis-quickstart/tutorials/hello_episode.py
+++ b/examples/noesis-quickstart/tutorials/hello_episode.py
@@ -86,9 +86,6 @@ def main() -> int:
     headline("Hello Episode — See Your Agent Think")
 
     try:
-        load_dotenv_if_present()
-        require_openai_key()
-
         ns = import_noesis()
 
         demo_files = write_demo_files(DEMO_ROOT)

--- a/noesis/cli/viewer.py
+++ b/noesis/cli/viewer.py
@@ -292,7 +292,6 @@ _PHASE_PAYLOAD_KEYS: Dict[str, Tuple[str, ...]] = {
     "plan": ("steps",),
     "act": ("outcome",),
     "reflect": ("success",),
-    "learn": ("policy_id", "basis", "proposal", "applied", "scope"),
     "governance": ("decision", "rule_id"),
     "direction": ("status",),
 }
@@ -334,6 +333,18 @@ def validate_events(events: Sequence[Dict[str, Any]], *, schema: str, file_label
                 issue = _require(key in payload, file=file_label, schema=schema, pointer=f"payload.{key}", message="missing", line=index)
                 if issue:
                     issues.append(issue)
+            if phase == "learn":
+                has_ref = any(key in payload for key in ("learn_path", "learn_schema"))
+                if has_ref:
+                    for key in ("learn_path", "learn_schema", "proposal_count", "proposal_ids"):
+                        issue = _require(key in payload, file=file_label, schema=schema, pointer=f"payload.{key}", message="missing", line=index)
+                        if issue:
+                            issues.append(issue)
+                else:
+                    for key in ("policy_id", "basis", "proposal", "scope"):
+                        issue = _require(key in payload, file=file_label, schema=schema, pointer=f"payload.{key}", message="missing", line=index)
+                        if issue:
+                            issues.append(issue)
             if phase == "act":
                 has_tool = any(k in payload for k in ("tool", "adapter"))
                 issue = _require(has_tool, file=file_label, schema=schema, pointer="payload.tool", message="requires 'tool' or 'adapter'", line=index)

--- a/noesis/core.py
+++ b/noesis/core.py
@@ -46,7 +46,9 @@ from .runtime.clock import RuntimeClock
 from .runtime.events_emitter import CognitiveEventEmitter
 from .runtime.prompt_recorder import PromptRecorder
 from .runtime.events import start_event as _start_event, terminate_event as _terminate_event
+from .runtime.normalization import normalize_using
 from .runtime.summary import finalize_summary as _finalize_summary
+from .runtime.learning import ensure_learn_file
 from .trace.schema import SUMMARY_SCHEMA_VERSION
 from .runtime.artifacts.ids import EpisodeIds
 from .runtime.artifacts.writer import ManifestWriter
@@ -335,7 +337,8 @@ def _bootstrap_episode(
     state_path = ctx.run_dir / "state.json"
 
     event_id_factory = determinism.rng.event_id_factory(ids.directive_namespace) if determinism else None
-    start_payload = {"task": task, "seed": seed, "using": raw_using_label}
+    using_norm = normalize_using(raw_using_label)
+    start_payload = {"task": task, "seed": seed, "using": using_norm.display if using_norm else raw_using_label}
     _start_event(
         ctx.run_dir,
         ctx.episode_id,
@@ -404,11 +407,13 @@ def _run_episode(
         intuition_enabled=setup.intuition_enabled,
     )
     runner = EpisodeRunner(deps, instrumentation=instrumentation)
+    using_norm = normalize_using(setup.raw_using_label)
+    using_label = using_norm.display if using_norm else setup.raw_using_label
     episode_request = EpisodeRequest(
         goal=task,
         beliefs=tuple(),
         context=setup.episode_ctx,
-        using_label=setup.raw_using_label,
+        using_label=using_label,
     )
     result = runner.run(episode_request)
 
@@ -434,6 +439,7 @@ def _run_episode(
         )
 
     state = result.state
+    ensure_learn_file(setup.ctx.run_dir)
     state.set_links(
         events="events.jsonl",
         summary="summary.json",

--- a/noesis/infrastructure/state_repository.py
+++ b/noesis/infrastructure/state_repository.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Literal, Protocol, TYPE_CHECKING
 
 from noesis.runtime.serialization import atomic_write_json
+from noesis.runtime.normalization import normalize_using
 from noesis.domain.state import NoesisState, create_state
 
 if TYPE_CHECKING:
@@ -76,4 +77,9 @@ class RuntimeStateRepository(StateRepository):
 
 def _write_state(path: Path, state: NoesisState) -> None:
     payload = state.to_dict()
+    episode = payload.get("episode")
+    if isinstance(episode, dict):
+        normalized = normalize_using(episode.get("using"))
+        if normalized:
+            episode["using"] = normalized.display
     atomic_write_json(path, payload)

--- a/noesis/interfaces/observability.py
+++ b/noesis/interfaces/observability.py
@@ -63,7 +63,7 @@ class RuntimeEventBus(EventBus):
             episode_id=self.context.episode_id,
             verb=CognitiveVerb.PLAN,
             payload=payload,
-            timestamp=event_metrics.started_at,
+            timestamp=event_metrics.completed_at,
             event_id=self.event_id_factory(),
         )
         if event_metrics:
@@ -139,7 +139,7 @@ class RuntimeEventBus(EventBus):
             episode_id=self.context.episode_id,
             verb=CognitiveVerb.ACT,
             payload=payload,
-            timestamp=metrics.started_at,
+            timestamp=metrics.completed_at,
             event_id=self.event_id_factory(),
         )
         if metrics:
@@ -168,7 +168,7 @@ class RuntimeEventBus(EventBus):
             episode_id=self.context.episode_id,
             verb=CognitiveVerb.REFLECT,
             payload=payload,
-            timestamp=metrics.started_at,
+            timestamp=metrics.completed_at,
             event_id=self.event_id_factory(),
         )
         if metrics:

--- a/noesis/runtime/determinism.py
+++ b/noesis/runtime/determinism.py
@@ -46,11 +46,12 @@ class DeterministicClock:
 
     def stop(self, token: int) -> CognitiveMetrics:
         start = self.start_at + timedelta(milliseconds=token * self.tick_ms)
-        end = start + timedelta(milliseconds=self.tick_ms)
+        end_tick = max(token + 1, self._ticks)
+        end = self.start_at + timedelta(milliseconds=end_tick * self.tick_ms)
         return CognitiveMetrics(
             started_at=start,
             completed_at=end,
-            duration_ms=round(self.tick_ms, 3),
+            duration_ms=round((end - start).total_seconds() * 1000, 3),
         )
 
 

--- a/noesis/runtime/learning.py
+++ b/noesis/runtime/learning.py
@@ -30,6 +30,7 @@ __all__ = [
     "LearnStatus",
     "LearnProposal",
     "build_learn_payload",
+    "ensure_learn_file",
     "persist_episode_learning",
     "load_policy_snapshot",
     "update_policy_snapshot",
@@ -45,6 +46,15 @@ def _now() -> str:
 
 def _sanitize_policy_id(policy_id: str) -> str:
     return policy_id.replace("/", "_").replace(" ", "_")
+
+
+def ensure_learn_file(run_dir: Path) -> Path:
+    """Create learn.jsonl if it is missing (empty file is valid)."""
+    path = run_dir / "learn.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.touch()
+    return path
 
 
 def build_learn_payload(
@@ -78,10 +88,24 @@ def build_learn_payload(
     }
 
 
-def persist_episode_learning(run_dir: Path, payload: Dict[str, Any]) -> None:
+def persist_episode_learning(
+    run_dir: Path,
+    *,
+    episode_id: str,
+    agent_id: str,
+    payload: Dict[str, Any],
+) -> None:
     path = run_dir / "learn.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
-    record = {"timestamp": _now(), "payload": payload}
+    record_id = payload.get("id") or f"episode:{episode_id}"
+    record = {
+        "schema_version": "learn/1.0",
+        "id": record_id,
+        "episode_id": episode_id,
+        "agent_id": agent_id,
+        "timestamp": _now(),
+        "payload": payload,
+    }
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, ensure_ascii=False) + "\n")
 
@@ -295,6 +319,15 @@ def maybe_emit_learn_event(
         ),
     )
 
+    learn_event_payload: Dict[str, Any] = {
+        "learn_path": "learn.jsonl",
+        "learn_schema": "learn/1.0",
+        "proposal_ids": [learn_id] if proposal_dicts else [],
+        "proposal_count": len(proposals),
+        "applied": applied_any,
+    }
+
+    ensure_learn_file(run_dir)
     write_event(
         run_dir,
         {
@@ -302,13 +335,18 @@ def maybe_emit_learn_event(
             "episode_id": episode_id,
             "agent_id": "system",
             "phase": "learn",
-            "payload": payload,
+            "payload": learn_event_payload,
             "evidence_ids": [],
         },
     )
 
     if proposal_dicts:
-        persist_episode_learning(run_dir, payload)
+        persist_episode_learning(
+            run_dir,
+            episode_id=episode_id,
+            agent_id=policy_id or "system",
+            payload=payload,
+        )
         learn_home.mkdir(parents=True, exist_ok=True)
         update_policy_snapshot(learn_home, policy_id, proposal_dicts, gate_updates=gate_updates)
 

--- a/noesis/runtime/normalization.py
+++ b/noesis/runtime/normalization.py
@@ -1,0 +1,52 @@
+"""
+Normalization helpers for artifact emission.
+
+Keeps normalization logic centralized so artifacts stay consistent
+across emitters, summary computation, and state persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Tuple
+
+from noesis.domain.faculties.insight import InsightMetrics, build_insight_metrics, compute_metrics
+__all__ = [
+    "UsingNormalization",
+    "normalize_using",
+    "compute_summary_metrics_from_events",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class UsingNormalization:
+    """Normalized representation of a `using` label."""
+
+    display: str
+    using_kind: str | None = None
+    using_id: str | None = None
+
+
+def normalize_using(value: str | None) -> UsingNormalization | None:
+    """Return the canonical `using` label plus optional metadata."""
+    if value is None:
+        return None
+    raw = str(value)
+    if raw.startswith("adapter:"):
+        display = raw.split("adapter:", 1)[1]
+        return UsingNormalization(display=display, using_kind="adapter", using_id=raw)
+    return UsingNormalization(display=raw)
+
+
+def compute_summary_metrics_from_events(
+    events: Iterable[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], InsightMetrics]:
+    """Compute canonical summary metrics and aligned insight metrics from events."""
+    event_list = list(events)
+    summary_metrics = compute_metrics({}, event_list)
+    insight_metrics = build_insight_metrics(event_list, summary_metrics)
+    summary_metrics["plan_adherence"] = insight_metrics.plan_adherence
+    summary_metrics["tool_coverage"] = insight_metrics.tool_coverage
+    summary_metrics["veto_count"] = insight_metrics.veto_count
+    summary_metrics["success"] = insight_metrics.success
+    return summary_metrics, insight_metrics

--- a/noesis/runtime/summary.py
+++ b/noesis/runtime/summary.py
@@ -14,12 +14,12 @@ from noesis.state.episode import EpisodeSummary
 from noesis.trace.events import read_events, write_event, canonical_dumps
 from noesis.trace.summary import write_summary
 from noesis.domain.faculties import validate_hook_sequence
-from noesis.domain.faculties.insight import compute_metrics, build_insight_metrics
 from noesis.intuition import Intuition, IntuitionMode
 from noesis.interfaces.config import ConfigSnapshot
 
 from .learning import maybe_emit_learn_event
-from .utils import compute_duration, format_diff_item, now
+from .normalization import compute_summary_metrics_from_events, normalize_using
+from .utils import compute_duration, format_diff_item, now, parse_iso8601
 
 __all__ = ["finalize_summary"]
 
@@ -74,10 +74,11 @@ def finalize_summary(
         failure_policy = failure_policy.value
     if failure_policy is not None:
         flags["governance_failure_policy"] = str(failure_policy)
-    if using_label is not None:
-        flags["using"] = using_label
+    using_norm = normalize_using(using_label)
+    if using_norm is not None:
+        flags["using"] = using_norm.display
 
-    summary_metrics = compute_metrics({}, events)
+    summary_metrics, insight_metrics = compute_summary_metrics_from_events(events)
 
     summary = EpisodeSummary(
         schema_version=schema_version,
@@ -95,7 +96,6 @@ def finalize_summary(
     ).__dict__
 
     metrics_bucket = summary.setdefault("metrics", {})
-    insight_metrics = build_insight_metrics(events, summary_metrics)
     summary.setdefault("insight", {})["metrics"] = insight_metrics.to_mapping()
     metrics_bucket["intuition_events"] = sum(1 for e in events if e.get("phase") == "intuition")
 
@@ -140,14 +140,31 @@ def finalize_summary(
         except Exception:
             continue
 
+    insight_payload: dict[str, object] = {
+        "summary_path": "summary.json",
+        "metrics": {
+            "plan_adherence": metrics_bucket.get("plan_adherence"),
+            "tool_coverage": metrics_bucket.get("tool_coverage"),
+            "veto_count": metrics_bucket.get("veto_count"),
+            "success": metrics_bucket.get("success"),
+            "act_count": metrics_bucket.get("act_count"),
+        },
+    }
+    insight_timestamp = now()
+    latest_ts = _latest_event_timestamp(events)
+    if latest_ts:
+        latest_dt = parse_iso8601(latest_ts)
+        current_dt = parse_iso8601(insight_timestamp)
+        if latest_dt and current_dt and current_dt < latest_dt:
+            insight_timestamp = latest_ts
     write_event(
         run_dir,
         {
-            "timestamp": now(),
+            "timestamp": insight_timestamp,
             "episode_id": episode_id,
             "agent_id": "system",
             "phase": "insight",
-            "payload": summary.get("metrics", {}),
+            "payload": insight_payload,
             "evidence_ids": [],
         },
     )
@@ -166,3 +183,19 @@ def finalize_summary(
     manifest_meta.setdefault("path", "manifest.json")
 
     write_summary(run_dir, summary)
+
+
+def _latest_event_timestamp(events: List[Dict[str, Any]]) -> Optional[str]:
+    latest_dt = None
+    latest_ts = None
+    for event in events:
+        ts = event.get("timestamp")
+        if not isinstance(ts, str):
+            continue
+        parsed = parse_iso8601(ts)
+        if parsed is None:
+            continue
+        if latest_dt is None or parsed > latest_dt:
+            latest_dt = parsed
+            latest_ts = ts
+    return latest_ts

--- a/noesis/trace/events.py
+++ b/noesis/trace/events.py
@@ -24,6 +24,9 @@ from typing import Any, Dict, Iterator, List, Callable
 import json
 import warnings
 
+from datetime import datetime
+from uuid import uuid4
+
 from noesis.domain.state.cognitive import CognitiveEvent
 
 JsonDefault = Callable[[Any], Any]
@@ -72,13 +75,19 @@ PHASES: set[str] = {
     *VERB_PHASES,
 }
 
+FACULTY_PHASES: dict[str, str] = {
+    "intuition": "intuition",
+    "direction": "direction",
+    "governance": "governance",
+    "insight": "insight",
+}
+
 _VERB_PAYLOAD_MINIMA: dict[str, set[str]] = {
     "observe": {"task", "tags", "timestamp"},
     "interpret": {"signals"},
     "plan": {"steps"},
     "act": {"input_excerpt", "outcome"},
     "reflect": {"success"},
-    "learn": {"policy_id", "basis", "proposal", "applied", "scope"},
 }
 
 # Minimal schema contract for events
@@ -102,6 +111,7 @@ __all__ = [
     "write_cognitive_event",
     "iter_events",
     "read_events",
+    "FACULTY_PHASES",
 ]
 
 
@@ -149,12 +159,42 @@ def _validate_event_schema(event: Dict[str, Any]) -> None:
             raise ValueError("act payload requires either 'tool' or 'adapter'")
         if phase == "learn":
             payload = event["payload"]
-            if not isinstance(payload.get("proposal"), list):
-                raise ValueError("learn payload 'proposal' must be a list")
+            has_ref = any(key in payload for key in ("learn_path", "learn_schema"))
+            if has_ref:
+                missing = {"learn_path", "learn_schema", "proposal_ids", "proposal_count"} - payload.keys()
+                if missing:
+                    raise ValueError(
+                        f"learn payload missing required keys: {sorted(missing)}"
+                    )
+                if not isinstance(payload.get("proposal_ids"), list):
+                    raise ValueError("learn payload 'proposal_ids' must be a list")
+                if not isinstance(payload.get("proposal_count"), int):
+                    raise ValueError("learn payload 'proposal_count' must be an int")
+                if "applied" in payload and not isinstance(payload.get("applied"), bool):
+                    raise ValueError("learn payload 'applied' must be a bool when provided")
+                if "applied_count" in payload and not isinstance(payload.get("applied_count"), int):
+                    raise ValueError("learn payload 'applied_count' must be an int when provided")
+            else:
+                missing = {"policy_id", "basis", "proposal", "scope"} - payload.keys()
+                if missing:
+                    raise ValueError(
+                        f"learn payload missing required keys: {sorted(missing)}"
+                    )
+    faculty = event.get("faculty")
+    if faculty is not None and not isinstance(faculty, str):
+        raise ValueError("event.faculty must be a string when provided")
+    if isinstance(faculty, str) and faculty not in FACULTY_PHASES.values():
+        raise ValueError(f"event.faculty must be one of {sorted(set(FACULTY_PHASES.values()))}")
 
 
 def write_event(dir_path: Path, event: Dict[str, Any], *, validate: bool = True) -> None:
     """Append a single JSON event line (optionally schema-validated)."""
+    if "id" not in event:
+        event["id"] = str(uuid4())
+    _normalize_event_timestamp(event, last_timestamp=_last_event_timestamp(dir_path))
+    phase = event.get("phase")
+    if isinstance(phase, str) and phase in FACULTY_PHASES and "faculty" not in event:
+        event["faculty"] = FACULTY_PHASES[phase]
     if validate:
         _validate_event_schema(event)
     _ensure_manifest_not_sealed(dir_path)
@@ -198,6 +238,73 @@ def iter_events(dir_path: Path) -> Iterator[Dict[str, Any]]:
 def read_events(dir_path: Path) -> List[Dict[str, Any]]:
     """Return all events ([] if none)."""
     return list(iter_events(dir_path) or ())
+
+
+def _last_event_timestamp(dir_path: Path) -> str | None:
+    path = dir_path / EVENTS_FILE
+    if not path.exists():
+        return None
+    with path.open("rb") as handle:
+        handle.seek(0, 2)
+        end = handle.tell()
+        if end == 0:
+            return None
+        buffer = bytearray()
+        pos = end - 1
+        while pos >= 0:
+            handle.seek(pos)
+            chunk = handle.read(1)
+            if chunk == b"\n" and buffer:
+                break
+            if chunk != b"\n":
+                buffer.extend(chunk)
+            pos -= 1
+        if not buffer:
+            return None
+        try:
+            payload = json.loads(buffer[::-1].decode("utf-8"))
+        except json.JSONDecodeError:
+            return None
+        ts = payload.get("timestamp")
+        return ts if isinstance(ts, str) else None
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _normalize_event_timestamp(event: Dict[str, Any], *, last_timestamp: str | None) -> str:
+    """
+    Normalize event timestamps to ensure monotonic ordering.
+
+    Rules:
+    - If metrics.completed_at is present, event.timestamp must equal it.
+    - Event timestamps must be >= the last emitted timestamp.
+    """
+    metrics = event.get("metrics")
+    has_metrics = isinstance(metrics, dict)
+    if has_metrics:
+        completed_at = metrics.get("completed_at")
+        if isinstance(completed_at, str):
+            event["timestamp"] = completed_at
+    timestamp = event.get("timestamp")
+    if not isinstance(timestamp, str):
+        raise ValueError("event.timestamp must be an ISO 8601 string")
+
+    if last_timestamp:
+        current = _parse_iso(timestamp)
+        prior = _parse_iso(last_timestamp)
+        if current is not None and prior is not None and current < prior:
+            if has_metrics:
+                raise ValueError(
+                    f"event.timestamp {timestamp} is older than prior event timestamp {last_timestamp}"
+                )
+            event["timestamp"] = last_timestamp
+            timestamp = last_timestamp
+    return timestamp
 
 
 def is_terminate_event(event: Dict[str, Any]) -> bool:

--- a/noesis/trace/schema.py
+++ b/noesis/trace/schema.py
@@ -41,6 +41,7 @@ class EventRecord(TypedDict, total=False):
     phase: str
     payload: Dict[str, Any]
     evidence_ids: List[str]
+    faculty: NotRequired[str]
     caused_by: NotRequired[str]
     metrics: NotRequired[EventMetrics]
 

--- a/noesis/usecases/episode_runner.py
+++ b/noesis/usecases/episode_runner.py
@@ -39,6 +39,7 @@ from noesis.runtime.clock import RuntimeClock
 from noesis.runtime.events_emitter import CognitiveEventEmitter
 from noesis.runtime.artifacts.ids import directive_uuid, governance_uuid
 from noesis.trace.events import read_events
+from noesis.runtime.normalization import normalize_using
 from .hooks.meta_phase import CompositeMetaPhaseHook, MetaPhaseHook, NullMetaPhaseHook
 from .ports import (
     ClockPort,
@@ -330,7 +331,7 @@ class EpisodeRunner:
             episode_id=context.episode_id,
             verb=verb,
             payload=payload,
-            timestamp=metrics.started_at or self._now(),
+            timestamp=metrics.completed_at or self._now(),
             event_id=event_id,
         ).with_metrics(metrics)
         linked = self._lineage.register(event, cause=cause)
@@ -600,11 +601,11 @@ class EpisodeRunner:
         token = self._clock.start(verb)
         metrics = self._clock.stop(token)
         payload: Dict[str, object] = {
-            "policy_id": "policy:core.minimal",
-            "basis": actuation.reasons,
-            "proposal": [],
+            "learn_path": "learn.jsonl",
+            "learn_schema": "learn/1.0",
+            "proposal_ids": [],
+            "proposal_count": 0,
             "applied": False,
-            "scope": "episode",
         }
         return self._emit_event(
             verb=verb,
@@ -682,6 +683,12 @@ class EpisodeRunner:
 
     def _build_snapshot(self, request: EpisodeRequest, state: NoesisState) -> Dict[str, object]:
         using_label = request.using_label or request.context.adapter_label
+        normalized = normalize_using(using_label)
+        display_label = normalized.display if normalized else using_label
+        snapshot_state = state.to_dict()
+        episode_block = snapshot_state.get("episode")
+        if isinstance(episode_block, dict):
+            episode_block["using"] = display_label
         return {
             "task": request.goal,
             "seed": request.context.seed,
@@ -689,8 +696,8 @@ class EpisodeRunner:
             "tools_seen": [],
             "tags": request.context.tags,
             "state_path": "state.json",
-            "state": state.to_dict(),
-            "using": using_label,
+            "state": snapshot_state,
+            "using": display_label,
         }
 
 

--- a/tests/runtime/test_artifact_invariants.py
+++ b/tests/runtime/test_artifact_invariants.py
@@ -1,0 +1,217 @@
+import json
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from importlib.util import find_spec
+from pathlib import Path
+
+import pytest
+from jsonschema import validate
+
+from noesis.runtime.artifacts.manifest import compute_sha256
+from noesis.runtime.normalization import normalize_using
+
+
+def _load_schema(name: str, version: str) -> dict:
+    path = Path(__file__).resolve().parents[2] / "docs" / "schema" / name / f"{version}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@contextmanager
+def _tutorial_context(tmp_path: Path) -> Path:
+    tutorial_root = Path(__file__).resolve().parents[2] / "examples" / "noesis-quickstart"
+    runs_dir = tmp_path / "runs"
+    learn_dir = tmp_path / "learn"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    learn_dir.mkdir(parents=True, exist_ok=True)
+
+    original_cwd = Path.cwd()
+    original_env = dict(os.environ)
+    sys.path.insert(0, str(tutorial_root))
+    os.environ["NOESIS_RUNS_DIR"] = str(runs_dir)
+    os.environ["NOESIS_LEARN_HOME"] = str(learn_dir)
+    os.chdir(tmp_path)
+    try:
+        yield runs_dir
+    finally:
+        os.chdir(original_cwd)
+        os.environ.clear()
+        os.environ.update(original_env)
+        if sys.path and sys.path[0] == str(tutorial_root):
+            sys.path.pop(0)
+
+
+def _parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _read_events(run_dir: Path) -> list[dict]:
+    events_path = run_dir / "events.jsonl"
+    return [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _validate_manifest(run_dir: Path) -> dict:
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    schema = _load_schema("manifest", "1.0.0")
+    validate(instance=manifest, schema=schema)
+    for item in manifest.get("files", []):
+        path = run_dir / item["name"]
+        assert path.exists(), f"manifest listed missing file: {path}"
+        assert item["size_bytes"] == path.stat().st_size
+        assert item["sha256"] == compute_sha256(path)
+    return manifest
+
+
+def _validate_events(run_dir: Path) -> list[dict]:
+    schema = _load_schema("event", "1.2.0")
+    events = _read_events(run_dir)
+    for event in events:
+        validate(instance=event, schema=schema)
+    return events
+
+
+def _validate_summary(run_dir: Path) -> dict:
+    summary = json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+    schema = _load_schema("summary", "1.2.0")
+    validate(instance=summary, schema=schema)
+    return summary
+
+
+def _validate_learn(run_dir: Path) -> list[dict]:
+    learn_path = run_dir / "learn.jsonl"
+    if not learn_path.exists():
+        return []
+    schema = _load_schema("learn", "1.0.0")
+    records = [
+        json.loads(line)
+        for line in learn_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    for record in records:
+        validate(instance=record, schema=schema)
+    return records
+
+
+def _assert_monotonic_timestamps(events: list[dict]) -> None:
+    last: datetime | None = None
+    for event in events:
+        ts = event.get("timestamp")
+        if not isinstance(ts, str):
+            continue
+        current = _parse_ts(ts)
+        if last is not None:
+            assert current >= last, "event timestamps are not monotonic"
+        last = current
+
+
+def _act_count(events: list[dict]) -> int:
+    count = 0
+    for event in events:
+        if event.get("phase") != "act":
+            continue
+        payload = event.get("payload")
+        if isinstance(payload, dict) and payload.get("synthetic"):
+            continue
+        count += 1
+    return count
+
+
+def _validate_cross_links(run_dir: Path, events: list[dict], summary: dict, manifest: dict) -> None:
+    state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
+    normalized = normalize_using(state.get("episode", {}).get("using"))
+    expected_using = normalized.display if normalized else state.get("episode", {}).get("using")
+
+    assert summary["flags"]["using"] == expected_using
+
+    start_events = [event for event in events if event.get("phase") == "start"]
+    if start_events:
+        start_using = (start_events[-1].get("payload") or {}).get("using")
+        assert start_using == expected_using
+
+    learn_records = _validate_learn(run_dir)
+    learn_ids = {record.get("id") for record in learn_records if record.get("id")}
+    learn_event_paths = [
+        event.get("payload", {}).get("learn_path")
+        for event in events
+        if event.get("phase") == "learn"
+    ]
+    if any(path == "learn.jsonl" for path in learn_event_paths):
+        learn_path = run_dir / "learn.jsonl"
+        assert learn_path.exists()
+        assert state.get("links", {}).get("learn") == "learn.jsonl"
+        manifest_files = manifest.get("files", [])
+        assert any(
+            item.get("kind") == "learn" and item.get("name") == "learn.jsonl"
+            for item in manifest_files
+        )
+
+    for event in events:
+        if event.get("phase") != "learn":
+            continue
+        payload = event.get("payload") or {}
+        assert payload.get("learn_path") == "learn.jsonl"
+        assert payload.get("learn_schema") == "learn/1.0"
+        assert isinstance(payload.get("proposal_count"), int)
+        proposal_ids = payload.get("proposal_ids") or []
+        assert all(pid in learn_ids for pid in proposal_ids)
+        assert isinstance(proposal_ids, list)
+
+
+def _validate_insight_consistency(events: list[dict], summary: dict) -> None:
+    expected = {
+        "plan_adherence": summary["metrics"].get("plan_adherence"),
+        "tool_coverage": summary["metrics"].get("tool_coverage"),
+        "veto_count": summary["metrics"].get("veto_count"),
+        "success": summary["metrics"].get("success"),
+        "act_count": summary["metrics"].get("act_count"),
+    }
+    insight_events = [event for event in events if event.get("phase") == "insight"]
+    if not insight_events:
+        return
+    payload = insight_events[-1].get("payload") or {}
+    metrics = payload.get("metrics") or {}
+    assert metrics == expected
+
+
+def _validate_run(run_dir: Path) -> None:
+    events = _validate_events(run_dir)
+    summary = _validate_summary(run_dir)
+    manifest = _validate_manifest(run_dir)
+
+    _assert_monotonic_timestamps(events)
+    assert summary["metrics"].get("act_count") == _act_count(events)
+    _validate_cross_links(run_dir, events, summary, manifest)
+    _validate_insight_consistency(events, summary)
+
+
+def test_artifact_invariants_hello_and_veto(tmp_path: Path) -> None:
+    with _tutorial_context(tmp_path) as runs_dir:
+        from tutorials import hello_episode
+
+        assert hello_episode.main() == 0
+        episodes = [p for p in runs_dir.iterdir() if p.is_dir() and p.name != "_episodes"]
+        assert episodes, "hello_episode did not emit an episode"
+        _validate_run(max(episodes, key=lambda p: p.stat().st_mtime))
+
+    if find_spec("langgraph") is None or find_spec("openai") is None:
+        pytest.skip("guarded_langgraph dependencies missing")
+    if not os.getenv("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set for guarded_langgraph tutorial")
+
+    with _tutorial_context(tmp_path / "guarded") as runs_dir:
+        from tutorials import guarded_langgraph
+
+        assert guarded_langgraph.main() == 0
+        episodes = [p for p in runs_dir.iterdir() if p.is_dir() and p.name != "_episodes"]
+        assert episodes, "guarded_langgraph did not emit episodes"
+        veto_runs = []
+        for episode_dir in episodes:
+            summary_path = episode_dir / "summary.json"
+            if not summary_path.exists():
+                continue
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            if summary.get("status") == "vetoed":
+                veto_runs.append(episode_dir)
+        assert veto_runs, "guarded_langgraph did not emit a vetoed episode"
+        _validate_run(veto_runs[-1])

--- a/tests/runtime/test_learning_apply.py
+++ b/tests/runtime/test_learning_apply.py
@@ -77,7 +77,9 @@ def test_learn_auto_apply_gate(tmp_path):
 
         learn_log = list((runs_dir / "ep_1" / "learn.jsonl").read_text(encoding="utf-8").splitlines())
         assert learn_log, "expected learn log for applied proposal"
-        payload = json.loads(learn_log[-1])["payload"]
+        record = json.loads(learn_log[-1])
+        assert record["schema_version"] == "learn/1.0"
+        payload = record["payload"]
         proposal = payload["proposal"][0]
         assert proposal["status"] == "applied"
         assert proposal["revert_handle"]["previous"] == 0.3

--- a/tests/state/test_state_artifacts.py
+++ b/tests/state/test_state_artifacts.py
@@ -26,7 +26,7 @@ def test_state_artifact_written(tmp_path) -> None:
         assert payload["outcomes"]["status"] == "ok"
         actions = payload["outcomes"]["actions"]
         assert actions and {"id", "kind", "tool", "result_status"}.issubset(actions[0].keys())
-        assert payload["episode"]["using"] in {"adapter:core.minimal", "adapter:core.null"}
+        assert payload["episode"]["using"] in {"core.minimal", "core.null"}
         assert payload["version"] == "1.0"
         assert payload["state_schema_version"] == "1.0.0"
         assert payload["links"]["events"] == "events.jsonl"


### PR DESCRIPTION
## Summary

Noēsis artifacts (`events.jsonl`, `summary.json`, `state.json`, `manifest.json`, optional `learn.jsonl`) are the contract for the CLI and any future telemetry/dashboard. We observed real runs producing inconsistencies that break chronological rendering, schema validation, and metric trustworthiness (e.g., non-monotonic timestamps, `using` mismatches, conflicting metrics, and learn payload drift).

This PR hardens the artifact contract by introducing centralized normalization and schema-backed invariant tests, without changing behavior outside artifact correctness.

## What changed

### 1) Event timestamp correctness + ordering
- If `event.metrics.completed_at` is present, **event.timestamp is forced to `completed_at`**.
- Events are written/validated with **non-decreasing timestamps**, ensuring `events.jsonl` is naturally renderable without re-sorting.

### 2) Canonical `using` normalization
- `using` is normalized consistently across:
  - `start.payload.using`
  - `state.episode.using`
  - `summary.flags.using`
- Canonical display label strips `adapter:` (human display), while optional identifiers can be preserved separately as needed.

### 3) Canonical summary metrics derived from events
- `summary.json` is the **canonical derived metrics source**.
- Summary metrics are computed deterministically from `events.jsonl`.
- The `insight` phase event payload is now a **stable subset** that must match `summary.metrics` exactly (no drift).

### 4) Learn artifacts design (Design A) + compatibility
- **Design A adopted**: learn proposals live **only** in `learn.jsonl` under a strict `learn/1.0` envelope.
- `phase="learn"` events emit **references only** (`learn_path`, `learn_schema`, `proposal_count`, `proposal_ids`, optional applied/applied_count).
- Ensures `learn.jsonl` is **materialized whenever referenced** (empty file allowed) so:
  `events.jsonl` ↔ `state.json` links ↔ `manifest.json` always agree.
- Schema retains **legacy compatibility** via `oneOf` for the learn phase payload.

### 5) Faculties support (optional)
- Adds optional `faculty` field for clean UI grouping:
  - intuition → direction → governance → insight
  - other phases omit faculty (no new faculties invented)

## Schemas added/updated
- `docs/schema/event/*` (event schema supports optional faculty + learn payload oneOf)
- `docs/schema/summary/*` (required fields enforced)
- `docs/schema/manifest/*` (file listing, sha256, sizes)
- `docs/schema/learn/*` (strict learn/1.0 envelope)

## Tests added/updated
- New invariant test validates real runs:
  - timestamps monotonic
  - `using` normalized everywhere
  - summary metrics deterministic from events and match insight subset
  - learn references imply learn file presence + state link + manifest inclusion
  - viewer validation accepts Design A learn references
- Existing learning/state artifact tests updated to align with the new invariants.

## Files changed

- `noesis/core.py`
- `noesis/infrastructure/state_repository.py`
- `noesis/interfaces/observability.py`
- `noesis/runtime/determinism.py`
- `noesis/runtime/learning.py`
- `noesis/runtime/normalization.py` *(new)*
- `noesis/runtime/summary.py`
- `noesis/trace/events.py`
- `noesis/trace/schema.py`
- `noesis/usecases/episode_runner.py`
- `noesis/cli/viewer.py`
- `tests/runtime/test_artifact_invariants.py` *(new)*
- `tests/runtime/test_learning_apply.py`
- `tests/state/test_state_artifacts.py`
- `docs/schema/event/*` *(new)*
- `docs/schema/learn/*` *(new)*
- `docs/schema/manifest/*` *(new)*
- `docs/schema/summary/*` *(new)*

## How to verify

```bash
uv run python -m tutorials.hello_episode
noesis view <EPISODE_ID>   # should show no schema validation errors

uv run pytest -q