### PR TITLE
fix: CLI Adaptive Breakpoint System

### DIFF
--- a/noesis/cli/render/richy.py
+++ b/noesis/cli/render/richy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, Iterable
 
 from rich import box
@@ -13,6 +15,103 @@ from rich.syntax import Syntax
 from .. import formatters
 from ..view_models import EpisodeDashboardVM, TimelineRowVM
 
+
+# ---------------------------------------------------------------------------
+# Responsive Breakpoints (inspired by CSS media queries)
+# ---------------------------------------------------------------------------
+
+class Breakpoint(Enum):
+    """Terminal width breakpoints for adaptive layouts."""
+    COMPACT = "compact"    # < 60 cols  (mobile-like, single column)
+    STANDARD = "standard"  # 60-99 cols (typical split terminal)
+    WIDE = "wide"          # >= 100 cols (full-width terminal)
+
+
+# Breakpoint thresholds
+_COMPACT_MAX = 60
+_STANDARD_MAX = 100
+
+
+def detect_breakpoint(console: Console) -> Breakpoint:
+    """Detect the current breakpoint based on console width."""
+    width = console.size.width
+    if width < _COMPACT_MAX:
+        return Breakpoint.COMPACT
+    if width < _STANDARD_MAX:
+        return Breakpoint.STANDARD
+    return Breakpoint.WIDE
+
+
+# ---------------------------------------------------------------------------
+# Adaptive Column Configurations
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ColumnConfig:
+    """Configuration for a table column at a specific breakpoint."""
+    name: str
+    width: int | None
+    visible: bool = True
+    no_wrap: bool = True
+    justify: str = "left"
+
+
+# Timeline columns per breakpoint
+_TIMELINE_CONFIGS: dict[Breakpoint, list[ColumnConfig]] = {
+    Breakpoint.COMPACT: [
+        ColumnConfig("Δt", width=7, justify="right"),
+        ColumnConfig("PHASE", width=8),
+        ColumnConfig("SUMMARY", width=None),  # flex
+    ],
+    Breakpoint.STANDARD: [
+        ColumnConfig("Δt", width=8, justify="right"),
+        ColumnConfig("PHASE", width=10),
+        ColumnConfig("STATUS", width=8),
+        ColumnConfig("SUMMARY", width=None),  # flex
+    ],
+    Breakpoint.WIDE: [
+        ColumnConfig("Δt", width=8, justify="right"),
+        ColumnConfig("PHASE", width=12),
+        ColumnConfig("AGENT", width=16),
+        ColumnConfig("STATUS", width=10),
+        ColumnConfig("SUMMARY", width=50),
+    ],
+}
+
+# KPI columns per breakpoint
+_KPI_CONFIGS: dict[Breakpoint, list[ColumnConfig]] = {
+    Breakpoint.COMPACT: [
+        ColumnConfig("KPI", width=12),
+        ColumnConfig("VALUE", width=10, justify="right"),
+    ],
+    Breakpoint.STANDARD: [
+        ColumnConfig("KPI", width=14),
+        ColumnConfig("VALUE", width=14, justify="right"),
+    ],
+    Breakpoint.WIDE: [
+        ColumnConfig("KPI", width=16),
+        ColumnConfig("VALUE", width=16, justify="right"),
+    ],
+}
+
+# Phase breakdown columns per breakpoint
+_PHASE_CONFIGS: dict[Breakpoint, list[ColumnConfig]] = {
+    Breakpoint.COMPACT: [
+        ColumnConfig("PHASE", width=8),
+        ColumnConfig("MS", width=6, justify="right"),
+    ],
+    Breakpoint.STANDARD: [
+        ColumnConfig("PHASE", width=10),
+        ColumnConfig("DURATION", width=8, justify="right"),
+    ],
+    Breakpoint.WIDE: [
+        ColumnConfig("PHASE", width=12),
+        ColumnConfig("DURATION", width=10, justify="right"),
+    ],
+}
+
+
+# Legacy fixed widths (kept for backward compatibility)
 _TIMELINE_COLS = {
     "dt": 8,
     "phase": 12,
@@ -181,7 +280,7 @@ class RichRenderer:
         if not grep:
             return list(rows)
         terms = [term.strip().lower() for term in grep.split() if term.strip()]
-        filtered: list[TimelineRow] = []
+        filtered: list[TimelineRowVM] = []
         for row in rows:
             haystack = f"phase={row.phase} agent={row.agent} summary={row.summary}".lower()
             if all(term in haystack for term in terms):
@@ -189,6 +288,16 @@ class RichRenderer:
         return filtered
 
     def render_episode_dashboard(self, vm: EpisodeDashboardVM, *, grep: str | None = None, debug: bool = False) -> None:
+        """Render the episode dashboard with adaptive layout based on terminal width."""
+        bp = detect_breakpoint(self.console)
+        
+        self._render_header(vm)
+        self._render_kpis_and_phases(vm, bp)
+        self._render_timeline(vm, grep, bp)
+        self._render_suggestions(vm, bp)
+
+    def _render_header(self, vm: EpisodeDashboardVM) -> None:
+        """Render the episode header panel."""
         header = vm.header
         chips = vm.chips
 
@@ -211,7 +320,12 @@ class RichRenderer:
             header_body.add_row(Text(chip_text.plain, style="muted"))
         self.console.print(Panel(header_body, border_style="title"))
 
+    def _render_kpis_and_phases(self, vm: EpisodeDashboardVM, bp: Breakpoint) -> None:
+        """Render KPIs and phase breakdown with adaptive layout."""
+        kpi_config = _KPI_CONFIGS[bp]
+        phase_config = _PHASE_CONFIGS[bp]
         kpis = vm.kpis
+
         kpi_table = Table(
             title="[title]KPIs[/]",
             box=box.SQUARE,
@@ -219,40 +333,65 @@ class RichRenderer:
             header_style="title",
             expand=True,
         )
-        kpi_table.add_column("KPI", style=_safe_style(self.console, "key", "cyan"), no_wrap=True, width=_KPI_COLS["label"])
-        kpi_table.add_column("VALUE", style=_safe_style(self.console, "val", "white"), justify="right", width=_KPI_COLS["value"])
-        kpi_table.add_row("success%", _format_percent_value(kpis.success_pct))
-        kpi_table.add_row("plan_adherence", _format_ratio(kpis.plan_adherence))
-        kpi_table.add_row("veto_count", str(kpis.veto_count) if kpis.veto_count is not None else "—")
-        kpi_table.add_row("tool_coverage", _format_ratio(kpis.tool_coverage))
-        kpi_table.add_row("first_action", kpis.first_action or "—")
+        for col in kpi_config:
+            kpi_table.add_column(
+                col.name,
+                style=_safe_style(self.console, "key" if col.name == "KPI" else "val", "cyan" if col.name == "KPI" else "white"),
+                no_wrap=col.no_wrap,
+                width=col.width,
+                justify=col.justify,
+            )
+
+        # Adaptive KPI labels
+        kpi_labels = {
+            Breakpoint.COMPACT: ["success", "adherence", "veto", "coverage", "1st act"],
+            Breakpoint.STANDARD: ["success%", "plan_adhere", "veto_count", "tool_cov", "first_act"],
+            Breakpoint.WIDE: ["success%", "plan_adherence", "veto_count", "tool_coverage", "first_action"],
+        }
+        labels = kpi_labels[bp]
+        kpi_table.add_row(labels[0], _format_percent_value(kpis.success_pct))
+        kpi_table.add_row(labels[1], _format_ratio(kpis.plan_adherence))
+        kpi_table.add_row(labels[2], str(kpis.veto_count) if kpis.veto_count is not None else "—")
+        kpi_table.add_row(labels[3], _format_ratio(kpis.tool_coverage))
+        kpi_table.add_row(labels[4], kpis.first_action or "—")
 
         phase_panel = None
         if vm.phase_breakdown:
             phase_table = Table(
-                title="[title]Phase Breakdown[/]",
+                title="[title]Phases[/]" if bp == Breakpoint.COMPACT else "[title]Phase Breakdown[/]",
                 show_header=True,
                 header_style="title",
                 box=box.SQUARE,
                 expand=True,
             )
-            phase_table.add_column("PHASE", style=_safe_style(self.console, "val", "white"), no_wrap=True, width=_PHASE_COLS["phase"])
-            phase_table.add_column("DURATION", style=_safe_style(self.console, "muted", "dim"), justify="right", no_wrap=True, width=_PHASE_COLS["duration"])
+            for col in phase_config:
+                phase_table.add_column(
+                    col.name,
+                    style=_safe_style(self.console, "val", "white"),
+                    no_wrap=col.no_wrap,
+                    width=col.width,
+                    justify=col.justify,
+                )
             for item in vm.phase_breakdown:
                 phase_style = _phase_style(self.console, item.phase)
-                phase_table.add_row(Text(item.phase, style=phase_style), f"{item.ms} ms")
+                duration_str = f"{item.ms}ms" if bp == Breakpoint.COMPACT else f"{item.ms} ms"
+                phase_table.add_row(Text(item.phase, style=phase_style), duration_str)
             phase_panel = phase_table
 
-        if phase_panel and self.console.size.width >= 100:
+        # Side-by-side layout only on WIDE breakpoint
+        if phase_panel and bp == Breakpoint.WIDE:
             from rich.columns import Columns
-
             self.console.print(Columns([kpi_table, phase_panel], expand=True))
         else:
             self.console.print(kpi_table)
             if phase_panel:
                 self.console.print(phase_panel)
 
+    def _render_timeline(self, vm: EpisodeDashboardVM, grep: str | None, bp: Breakpoint) -> None:
+        """Render the timeline table with adaptive columns."""
+        timeline_config = _TIMELINE_CONFIGS[bp]
         rows = self._filter_timeline(vm.timeline_rows, grep)
+
         timeline_table = Table(
             title="[title]Timeline[/]",
             show_header=True,
@@ -260,32 +399,63 @@ class RichRenderer:
             box=box.SQUARE,
             expand=True,
         )
-        timeline_table.add_column("Δt", style=_safe_style(self.console, "muted", "dim"), no_wrap=True, justify="right", width=_TIMELINE_COLS["dt"])
-        timeline_table.add_column("PHASE", style=_safe_style(self.console, "val", "white"), no_wrap=True, width=_TIMELINE_COLS["phase"])
-        timeline_table.add_column("AGENT", style=_safe_style(self.console, "muted", "dim"), no_wrap=True, width=_TIMELINE_COLS["agent"])
-        timeline_table.add_column("STATUS", style=_safe_style(self.console, "val", "white"), no_wrap=True, width=_TIMELINE_COLS["status"])
-        timeline_table.add_column("SUMMARY", style=_safe_style(self.console, "val", "white"), no_wrap=True, width=_TIMELINE_COLS["summary"])
+
+        # Add columns based on breakpoint config
+        for col in timeline_config:
+            style = _safe_style(self.console, "muted", "dim") if col.name in ("Δt", "AGENT") else _safe_style(self.console, "val", "white")
+            timeline_table.add_column(
+                col.name,
+                style=style,
+                no_wrap=col.no_wrap,
+                width=col.width,
+                justify=col.justify,
+            )
 
         if not rows:
-            timeline_table.add_row("-", "-", "-", "-", "no events matched")
+            empty_row = ["-"] * len(timeline_config)
+            empty_row[-1] = "no events matched"
+            timeline_table.add_row(*empty_row)
         else:
             for row in rows:
                 phase_style = _phase_style(self.console, row.phase)
-                timeline_table.add_row(
-                    formatters.truncate(row.dt_str, max_width=_TIMELINE_COLS["dt"]),
-                    Text(formatters.truncate(row.phase, max_width=_TIMELINE_COLS["phase"]), style=phase_style),
-                    Text(formatters.truncate(row.agent, max_width=_TIMELINE_COLS["agent"]), style="muted"),
-                    Text(
-                        formatters.truncate(row.status or "—", max_width=_TIMELINE_COLS["status"]),
-                        style=_status_style(row.status),
-                    ),
-                    Text(formatters.truncate(row.summary or "", max_width=_TIMELINE_COLS["summary"]), style="val"),
-                )
+                row_data = self._build_timeline_row(row, bp, phase_style)
+                timeline_table.add_row(*row_data)
+
         self.console.print(timeline_table)
 
-        if vm.suggestions:
-            suggestions = "\n".join(f"[muted]$[/] {item}" for item in vm.suggestions)
-            self.console.print(Panel(suggestions, title="[title]Next[/]"))
+    def _build_timeline_row(self, row: TimelineRowVM, bp: Breakpoint, phase_style: str) -> list[Text | str]:
+        """Build a timeline row based on breakpoint."""
+        if bp == Breakpoint.COMPACT:
+            return [
+                formatters.truncate(row.dt_str, max_width=7),
+                Text(formatters.truncate(row.phase, max_width=8), style=phase_style),
+                Text(formatters.truncate(row.summary or "", max_width=40), style="val"),
+            ]
+        elif bp == Breakpoint.STANDARD:
+            return [
+                formatters.truncate(row.dt_str, max_width=8),
+                Text(formatters.truncate(row.phase, max_width=10), style=phase_style),
+                Text(formatters.truncate(row.status or "—", max_width=8), style=_status_style(row.status)),
+                Text(formatters.truncate(row.summary or "", max_width=50), style="val"),
+            ]
+        else:  # WIDE
+            return [
+                formatters.truncate(row.dt_str, max_width=8),
+                Text(formatters.truncate(row.phase, max_width=12), style=phase_style),
+                Text(formatters.truncate(row.agent, max_width=16), style="muted"),
+                Text(formatters.truncate(row.status or "—", max_width=10), style=_status_style(row.status)),
+                Text(formatters.truncate(row.summary or "", max_width=50), style="val"),
+            ]
+
+    def _render_suggestions(self, vm: EpisodeDashboardVM, bp: Breakpoint) -> None:
+        """Render the suggestions panel."""
+        if not vm.suggestions:
+            return
+        
+        # On compact, show fewer suggestions
+        suggestions_to_show = vm.suggestions[:2] if bp == Breakpoint.COMPACT else vm.suggestions
+        suggestions = "\n".join(f"[muted]$[/] {item}" for item in suggestions_to_show)
+        self.console.print(Panel(suggestions, title="[title]Next[/]"))
 
     def print_viewer(self, view: EpisodeDashboardVM, *, grep: str | None = None) -> None:
         self.render_episode_dashboard(view, grep=grep)


### PR DESCRIPTION
## Summary

### Adaptive Breakpoint System

Breakpoint enum with 3 tiers: COMPACT (<60 cols), STANDARD (60-99), WIDE (≥100)
detect_breakpoint(console) utility to check current terminal width
Responsive Column Configs
_TIMELINE_CONFIGS — compact hides AGENT/STATUS columns, standard hides AGENT
_KPI_CONFIGS / _PHASE_CONFIGS — adaptive widths per breakpoint
Shorter labels on compact (e.g., "success" vs "success%")
Refactored render_episode_dashboard
Now delegates to _render_header, _render_kpis_and_phases, _render_timeline, _render_suggestions
Each section adapts columns/layout based on detected breakpoint
Side-by-side KPIs + Phases only on WIDE; stacked otherwise
Compact shows fewer suggestions