### PR TITLE
Noesis CLI: home/help UX via registry-driven content + adaptive theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ rules.md
 docs/rules.md
 noesis/.env
 AGENTS.md
+CLAUDE.md
 
 
 # local runs

--- a/docs/internal/cli-phase1-plan.md
+++ b/docs/internal/cli-phase1-plan.md
@@ -1,0 +1,1117 @@
+# Phase 1: CLI Modernization Plan (Final)
+
+> **Goal**: Transform the Noēsis CLI into a polished, observability-first terminal experience with a unified registry as the single source of truth.
+
+---
+
+## 1. The Ideal First Impression
+
+When a user types `noesis`:
+
+```
+╭─────────────────────────────────────────────────────────────────────────────╮
+│  ◉ Noēsis v1.0.0                                    Cognitive Runtime CLI   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│   Observable episodes · Governance · Deterministic replay                   │
+│                                                                             │
+│   ┌─ Quick Start ────────────────────────────────────────────────────────┐  │
+│   │  $ noesis run "Summarize this repo"         Run a baseline episode   │  │
+│   │  $ noesis ps                                Recent episodes          │  │
+│   │  $ noesis view <episode_id>                 Inspect dashboard        │  │
+│   └──────────────────────────────────────────────────────────────────────┘  │
+│                                                                             │
+│   ┌─ Recent Episodes ────────────────────────────────────────────────────┐  │
+│   │  12:34  ep_01JX…YZ  success   "Summarize the changelog"      0.8s    │  │
+│   │  11:02  ep_01JW…AB  vetoed    "Deploy to prod"               1.2s    │  │
+│   └──────────────────────────────────────────────────────────────────────┘  │
+│                                                                             │
+│   ┌─ Observe ──────────────────┐  ┌─ Verify ─────────────────────────────┐  │
+│   │  ps         Recent runs    │  │  artifacts      Check integrity      │  │
+│   │  view       Dashboard      │  │  diagnostics    Replay compare       │  │
+│   │  events     Event stream   │  └──────────────────────────────────────┘  │
+│   └────────────────────────────┘                                            │
+│                                                                             │
+│   → noesis help                                                             │
+╰─────────────────────────────────────────────────────────────────────────────╯
+```
+
+**Exit code**: `0` — home is a valid response
+**No blocking**: No "Press Enter" interaction
+
+---
+
+## 2. Unified CommandSpec Registry (Single Source of Truth)
+
+### The Problem with Two Dicts
+
+Having `COMMANDS` and `COMMAND_META` as separate dicts creates drift. Commands get added but metadata isn't updated, or vice versa.
+
+### The Solution: Unified CommandSpec
+
+```python
+# noesis/cli/registry.py
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+import argparse
+
+
+class Command(Protocol):
+    """Protocol for CLI commands."""
+    name: str
+    help: str
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None: ...
+    def run(self, args: argparse.Namespace, ctx, renderer) -> int: ...
+
+
+CommandGroup = Literal["execute", "observe", "verify", "maintain"]
+
+
+@dataclass(frozen=True)
+class CommandMeta:
+    """Presentation metadata for a command."""
+    group: CommandGroup
+    one_liner: str
+    examples: tuple[str, ...] = ()
+    show_on_home: bool = False
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Unified command specification: logic + presentation."""
+    cmd: Command
+    meta: CommandMeta
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# UNIFIED REGISTRY (single source of truth)
+# ─────────────────────────────────────────────────────────────────────────────
+
+from .commands.run import RUN_COMMAND
+from .commands.solve import SOLVE_COMMAND
+from .commands.ps import PS_COMMAND
+from .commands.view import VIEW_COMMAND
+from .commands.list import LIST_COMMAND
+from .commands.show import SHOW_COMMAND
+from .commands.events import EVENTS_COMMAND
+from .commands.insight import INSIGHT_COMMAND
+from .commands.artifacts import ARTIFACTS_COMMAND
+from .commands.validate_ports import VALIDATE_PORTS_COMMAND
+from .commands.diagnostics import DIAGNOSTICS_COMMAND
+from .commands.migrate import MIGRATE_COMMAND
+from .commands.version import VERSION_COMMAND
+from .commands.new import NEW_COMMAND
+from .commands.help import HELP_COMMAND
+
+
+REGISTRY: dict[str, CommandSpec] = {
+    # ── Execute ──────────────────────────────────────────────────────────────
+    "run": CommandSpec(
+        cmd=RUN_COMMAND,
+        meta=CommandMeta(
+            group="execute",
+            one_liner="Run a baseline episode (no adapter)",
+            examples=('noesis run "Summarize this repo"',),
+            show_on_home=True,
+        ),
+    ),
+    "solve": CommandSpec(
+        cmd=SOLVE_COMMAND,
+        meta=CommandMeta(
+            group="execute",
+            one_liner="Run an episode with an adapter/flow",
+            examples=('noesis solve react "Weekly plan"',),
+        ),
+    ),
+
+    # ── Observe ──────────────────────────────────────────────────────────────
+    "ps": CommandSpec(
+        cmd=PS_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Compact table of recent episodes",
+            examples=("noesis ps", "noesis ps --limit 10"),
+            show_on_home=True,
+        ),
+    ),
+    "view": CommandSpec(
+        cmd=VIEW_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Inspect timeline, metrics, and governance",
+            examples=("noesis view <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "list": CommandSpec(
+        cmd=LIST_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="List recent episodes",
+            examples=("noesis list",),
+        ),
+    ),
+    "show": CommandSpec(
+        cmd=SHOW_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Show a single episode summary",
+            examples=("noesis show <episode_id>",),
+        ),
+    ),
+    "events": CommandSpec(
+        cmd=EVENTS_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Print or stream episode events",
+            examples=("noesis events <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "insight": CommandSpec(
+        cmd=INSIGHT_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Show computed insight metrics",
+            examples=("noesis insight <episode_id>",),
+        ),
+    ),
+
+    # ── Verify ───────────────────────────────────────────────────────────────
+    "artifacts": CommandSpec(
+        cmd=ARTIFACTS_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Manifest utilities and verification",
+            examples=("noesis artifacts verify <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "validate-ports": CommandSpec(
+        cmd=VALIDATE_PORTS_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Validate configured runtime ports",
+            examples=("noesis validate-ports",),
+        ),
+    ),
+    "diagnostics": CommandSpec(
+        cmd=DIAGNOSTICS_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Stability diagnostics and replay compare",
+            examples=("noesis diagnostics replay <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+
+    # ── Maintain ─────────────────────────────────────────────────────────────
+    "migrate": CommandSpec(
+        cmd=MIGRATE_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Codemod deprecated shims to the modern API",
+            examples=("noesis migrate --check",),
+        ),
+    ),
+    "version": CommandSpec(
+        cmd=VERSION_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Print CLI and core versions",
+            examples=("noesis version",),
+        ),
+    ),
+    "new": CommandSpec(
+        cmd=NEW_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Scaffold a starter flow or policy",
+            examples=("noesis new flow my_flow",),
+        ),
+    ),
+    "help": CommandSpec(
+        cmd=HELP_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Show help for commands",
+            examples=("noesis help", "noesis help view"),
+        ),
+    ),
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BACKWARDS COMPAT: expose COMMANDS dict for existing call sites
+# ─────────────────────────────────────────────────────────────────────────────
+
+COMMANDS: dict[str, Command] = {name: spec.cmd for name, spec in REGISTRY.items()}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# QUERY HELPERS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_specs_by_group(group: CommandGroup) -> list[CommandSpec]:
+    """Get all command specs in a group, sorted by name."""
+    return sorted(
+        [spec for spec in REGISTRY.values() if spec.meta.group == group],
+        key=lambda s: s.cmd.name,
+    )
+
+
+def get_home_specs() -> list[CommandSpec]:
+    """Get commands flagged for home screen display."""
+    return [spec for spec in REGISTRY.values() if spec.meta.show_on_home]
+
+
+def get_all_groups() -> tuple[CommandGroup, ...]:
+    """Get all group names in display order."""
+    return ("execute", "observe", "verify", "maintain")
+```
+
+---
+
+## 3. Content Builders (Derived from Registry)
+
+### File: `noesis/cli/content/home.py`
+
+```python
+"""Home screen content, derived from registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..registry import REGISTRY, get_specs_by_group
+
+
+@dataclass(frozen=True)
+class QuickStartItem:
+    command: str
+    description: str
+
+
+@dataclass(frozen=True)
+class CommandPreview:
+    name: str
+    one_liner: str
+
+
+@dataclass(frozen=True)
+class RecentEpisode:
+    """Recent episode for home screen (summary-only data)."""
+    time_str: str        # HH:MM
+    episode_short: str   # truncated ID (middle ellipsis)
+    status: str          # success | vetoed | error
+    task: str            # truncated task
+    duration: str        # e.g., "0.8s"
+
+
+@dataclass(frozen=True)
+class HomeScreen:
+    version: str
+    tagline: str
+    quick_start: tuple[QuickStartItem, ...]
+    recent_episodes: tuple[RecentEpisode, ...]
+    observe_commands: tuple[CommandPreview, ...]
+    verify_commands: tuple[CommandPreview, ...]
+    footer_hint: str
+
+
+def build_home_screen(
+    version: str,
+    *,
+    recent_episodes: Sequence[RecentEpisode] = (),
+) -> HomeScreen:
+    """Build home screen from registry metadata."""
+
+    # Quick start: curated set
+    quick_start_names = ["run", "ps", "view"]
+    quick_start = tuple(
+        QuickStartItem(
+            command=REGISTRY[name].meta.examples[0] if REGISTRY[name].meta.examples else f"noesis {name}",
+            description=REGISTRY[name].meta.one_liner,
+        )
+        for name in quick_start_names
+        if name in REGISTRY
+    )
+
+    # Observe group (show_on_home only)
+    observe = tuple(
+        CommandPreview(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+        for spec in get_specs_by_group("observe")
+        if spec.meta.show_on_home
+    )
+
+    # Verify group (show_on_home only)
+    verify = tuple(
+        CommandPreview(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+        for spec in get_specs_by_group("verify")
+        if spec.meta.show_on_home
+    )
+
+    return HomeScreen(
+        version=version,
+        tagline="Observable episodes · Governance · Deterministic replay",
+        quick_start=quick_start,
+        recent_episodes=tuple(recent_episodes),
+        observe_commands=observe,
+        verify_commands=verify,
+        footer_hint="noesis help",
+    )
+```
+
+### File: `noesis/cli/content/help.py`
+
+```python
+"""Help screen content, derived from registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..registry import REGISTRY, get_specs_by_group, get_all_groups, CommandGroup
+
+
+@dataclass(frozen=True)
+class CommandInfo:
+    name: str
+    one_liner: str
+
+
+@dataclass(frozen=True)
+class CommandGroupInfo:
+    title: str
+    commands: tuple[CommandInfo, ...]
+
+
+@dataclass(frozen=True)
+class HelpScreen:
+    version: str
+    tagline: str
+    usage: str
+    groups: tuple[CommandGroupInfo, ...]
+    examples: tuple[str, ...]
+    footer: str
+
+
+_GROUP_TITLES: dict[CommandGroup, str] = {
+    "execute": "Execute",
+    "observe": "Observe",
+    "verify": "Verify",
+    "maintain": "Maintain",
+}
+
+
+def build_help_screen(version: str) -> HelpScreen:
+    """Build help screen from registry metadata."""
+
+    groups = tuple(
+        CommandGroupInfo(
+            title=_GROUP_TITLES[group],
+            commands=tuple(
+                CommandInfo(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+                for spec in get_specs_by_group(group)
+            ),
+        )
+        for group in get_all_groups()
+    )
+
+    # Collect first example from each command (up to 5)
+    examples: list[str] = []
+    for spec in REGISTRY.values():
+        if spec.meta.examples:
+            examples.append(spec.meta.examples[0])
+        if len(examples) >= 5:
+            break
+
+    return HelpScreen(
+        version=version,
+        tagline="Run, inspect, and govern cognitive episodes.",
+        usage="noesis <command> [options]",
+        groups=groups,
+        examples=tuple(examples),
+        footer="Tip: noesis help <command> or noesis <command> -h for details.",
+    )
+```
+
+---
+
+## 4. Theme Tokens + Layout Tiers
+
+### File: `noesis/cli/theme.py`
+
+```python
+"""Theme tokens, layout constants, and breakpoints."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+
+class Breakpoint(Enum):
+    """Terminal width breakpoints."""
+    COMPACT = "compact"    # < 60 cols
+    STANDARD = "standard"  # 60-99 cols
+    WIDE = "wide"          # >= 100 cols
+
+
+COMPACT_MAX = 60
+STANDARD_MAX = 100
+
+
+def detect_breakpoint(width: int) -> Breakpoint:
+    """Detect breakpoint from terminal width."""
+    if width < COMPACT_MAX:
+        return Breakpoint.COMPACT
+    if width < STANDARD_MAX:
+        return Breakpoint.STANDARD
+    return Breakpoint.WIDE
+
+
+@dataclass(frozen=True)
+class ThemeLayout:
+    """Layout constants for consistent spacing."""
+    panel_padding: tuple[int, int] = (1, 2)
+    panel_width: int = 88
+    max_width: int = 100
+    min_width: int = 40
+    gutter: int = 2
+    indent: int = 2
+    command_col_width: int = 14
+    description_col_width: int = 40
+
+
+@dataclass(frozen=True)
+class ThemeTokens:
+    styles: Mapping[str, str]
+    layout: ThemeLayout = ThemeLayout()
+
+
+def build_theme_tokens() -> ThemeTokens:
+    return ThemeTokens(
+        styles={
+            # Text
+            "title": "bold bright_cyan",
+            "accent": "bright_cyan",
+            "muted": "grey66",
+            "hint": "dim",
+            "key": "bright_cyan",
+            "val": "white",
+
+            # Status
+            "ok": "green",
+            "warn": "yellow",
+            "err": "bold red",
+
+            # Structure
+            "border": "grey42",
+            "panel": "grey50",
+            "header": "bold bright_cyan",
+
+            # Badges
+            "badge": "black on bright_cyan",
+            "badge.success": "bold white on green",
+            "badge.warn": "bold black on yellow",
+            "badge.error": "bold white on red",
+
+            # Navigation
+            "nav.arrow": "bright_blue",
+            "nav.command": "bold bright_cyan",
+
+            # Groups
+            "group.title": "bold bright_cyan",
+
+            # Home
+            "home.tagline": "italic grey74",
+
+            # Phases (for timeline)
+            "phase.start": "cyan",
+            "phase.intuition": "magenta",
+            "phase.observe": "bright_black",
+            "phase.interpret": "bright_blue",
+            "phase.plan": "bright_cyan",
+            "phase.direction": "blue",
+            "phase.insight": "green",
+            "phase.act": "white",
+            "phase.reflect": "green",
+            "phase.learn": "cyan",
+            "phase.terminate": "yellow",
+            "phase.error": "bold red",
+        }
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ENFORCED STYLE: One border style everywhere
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_box_style():
+    """Return the single box style used across all Rich panels/tables."""
+    try:
+        from rich import box
+        return box.ROUNDED
+    except ImportError:
+        return None
+```
+
+---
+
+## 5. Renderer Updates
+
+### Key Rules
+
+1. **One box style**: Use `box.ROUNDED` for every Rich panel/table
+2. **No blocking**: Remove all `console.input()` calls
+3. **Help routing**: Command-specific help embeds argparse text in a styled panel
+
+### File: `noesis/cli/render/richy.py` (Key Methods)
+
+```python
+from rich import box
+
+# THE box style (enforced everywhere)
+_BOX = box.ROUNDED
+
+
+def print_home(self, screen: HomeScreen) -> None:
+    if self.quiet:
+        return
+
+    bp = detect_breakpoint(self.console.size.width)
+    border = _safe_style(self.console, "border", "grey42")
+
+    # Header
+    header_grid = Table.grid(expand=True)
+    header_grid.add_column(ratio=1)
+    header_grid.add_column(justify="right")
+    header_grid.add_row(
+        Text(f"Noēsis v{screen.version}", style="title"),
+        Text("Cognitive Runtime CLI", style="muted"),
+    )
+    header_grid.add_row(Text(screen.tagline, style="home.tagline"))
+    self.console.print(Panel(header_grid, box=_BOX, border_style=border))
+
+    # Quick Start
+    qs_body = "\n".join(
+        f"[muted]$[/] [nav.command]{item.command}[/]  [muted]{item.description}[/]"
+        for item in screen.quick_start
+    )
+    self.console.print(Panel(qs_body, title="[group.title]Quick Start[/]", box=_BOX, border_style=border))
+
+    # Recent Episodes (if any)
+    if screen.recent_episodes:
+        ep_table = Table(box=None, show_header=False, expand=True, padding=(0, 1))
+        ep_table.add_column("time", style="muted", width=5)
+        ep_table.add_column("id", style="accent", width=12)
+        ep_table.add_column("status", width=7)
+        ep_table.add_column("task", style="val")
+        ep_table.add_column("dur", style="muted", justify="right", width=5)
+
+        for ep in screen.recent_episodes[:5]:
+            ep_table.add_row(
+                ep.time_str,
+                ep.episode_short,
+                Text(ep.status, style=_status_style(ep.status)),
+                _truncate(ep.task, 35),
+                ep.duration,
+            )
+        self.console.print(Panel(ep_table, title="[group.title]Recent Episodes[/]", box=_BOX, border_style=border))
+
+    # Command groups
+    observe_body = "\n".join(f"[accent]{c.name:<12}[/] [muted]{c.one_liner}[/]" for c in screen.observe_commands)
+    verify_body = "\n".join(f"[accent]{c.name:<14}[/] [muted]{c.one_liner}[/]" for c in screen.verify_commands)
+
+    observe_panel = Panel(observe_body, title="[group.title]Observe[/]", box=_BOX, border_style=border)
+    verify_panel = Panel(verify_body, title="[group.title]Verify[/]", box=_BOX, border_style=border)
+
+    if bp == Breakpoint.WIDE:
+        from rich.columns import Columns
+        self.console.print(Columns([observe_panel, verify_panel], expand=True))
+    else:
+        self.console.print(observe_panel)
+        self.console.print(verify_panel)
+
+    # Footer
+    self.console.print(Text(f"→ {screen.footer_hint}", style="nav.arrow"))
+
+
+def print_command_help(self, text: str, *, title: str | None = None) -> None:
+    """Render command help (argparse text) in a styled panel."""
+    if self.quiet:
+        return
+    border = _safe_style(self.console, "border", "grey42")
+    # Embed argparse text as-is, but in a nice panel
+    self.console.print(Panel(
+        text.rstrip(),
+        title=f"[title]{title}[/]" if title else None,
+        box=_BOX,
+        border_style=border,
+    ))
+```
+
+---
+
+## 6. Main Routing
+
+### File: `noesis/cli/main.py`
+
+```python
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+
+    # Early help detection
+    help_target = _detect_help_target(raw_argv)
+    if help_target is not None:
+        options = _options_from_argv(raw_argv)
+        ctx = build_context(options, port_specs=[])
+        renderer = _select_renderer(ctx, options)
+        _render_help(renderer, ctx, command_name=help_target)
+        return 0
+
+    formatter = _choose_formatter()
+    parser, _ = build_parser(formatter)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return exc.code
+
+    # ... options extraction ...
+
+    ctx = build_context(options, port_specs)
+    renderer = _select_renderer(ctx, options)
+    command = getattr(args, "command_obj", None)
+
+    # ── NO COMMAND PROVIDED ──────────────────────────────────────────────────
+    if command is None:
+        if options.json:
+            return EXIT_USAGE  # exit 2, no output
+        if options.quiet:
+            return 0  # exit 0, no output
+
+        # Build home screen with recent episodes (summary-only)
+        recent = _fetch_recent_episodes(ctx, limit=5)
+        home = build_home_screen(ctx.version, recent_episodes=recent)
+        renderer.print_home(home)
+        return 0  # exit 0
+
+    # ── EXECUTE COMMAND ──────────────────────────────────────────────────────
+    provider = ns.session_provider()
+    try:
+        with provider.use(ctx.session):
+            return command.run(args, ctx, renderer)
+    except ns.NoesisVeto as veto:
+        print(veto.advice or "Vetoed by policy", file=sys.stderr)
+        return EXIT_VETO
+    except ValueError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return EXIT_USAGE
+    except Exception as err:
+        print(f"error: {err}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+def _fetch_recent_episodes(ctx, limit: int = 5) -> list[RecentEpisode]:
+    """
+    Fetch recent episodes for home screen.
+
+    HARD REQUIREMENT: Summary-only fast path.
+    - Read only summary.json per episode
+    - No events.jsonl, no schema parsing
+    - If slow or fails, return empty list
+    """
+    try:
+        from .content.home import RecentEpisode
+        from pathlib import Path
+        import json
+
+        runs_dir = Path(ctx.config_snapshot.runs_dir)
+        if not runs_dir.exists():
+            return []
+
+        # Find episode dirs, sort by mtime, limit
+        episode_dirs = sorted(
+            (d for d in runs_dir.iterdir() if d.is_dir() and (d / "summary.json").exists()),
+            key=lambda d: (d / "summary.json").stat().st_mtime,
+            reverse=True,
+        )[:limit]
+
+        results = []
+        for ep_dir in episode_dirs:
+            try:
+                summary = json.loads((ep_dir / "summary.json").read_text())
+                started = summary.get("started_at", "")[:5]  # HH:MM
+                episode_id = summary.get("episode_id", ep_dir.name)
+                # Truncate middle: ep_01JXYZ...1234
+                if len(episode_id) > 12:
+                    episode_short = episode_id[:7] + "…" + episode_id[-4:]
+                else:
+                    episode_short = episode_id
+                status = summary.get("outcome", {}).get("status", "?")
+                task = summary.get("task", "")[:35]
+                duration = f"{summary.get('duration_sec', 0):.1f}s"
+
+                results.append(RecentEpisode(
+                    time_str=started,
+                    episode_short=episode_short,
+                    status=status,
+                    task=task,
+                    duration=duration,
+                ))
+            except Exception:
+                continue
+
+        return results
+    except Exception:
+        return []
+```
+
+---
+
+## 7. Help Command
+
+### File: `noesis/cli/commands/help.py`
+
+```python
+"""Help command: noesis help [command]"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from ..context import CLIContext
+from ..content.help import build_help_screen
+from ..parser import build_command_parser
+from ..registry import REGISTRY
+
+
+@dataclass
+class HelpCommand:
+    name: str = "help"
+    help: str = "Show help for commands"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("command", nargs="?", help="Command to get help for")
+
+    def run(self, args: argparse.Namespace, ctx: CLIContext, renderer) -> int:
+        command_name = getattr(args, "command", None)
+
+        if command_name:
+            spec = REGISTRY.get(command_name)
+            if not spec:
+                renderer.echo(f"Unknown command: {command_name}")
+                renderer.print_help(build_help_screen(ctx.version))
+                return 2
+
+            # Get argparse help text and render it styled
+            command_parser = build_command_parser(command_name, argparse.RawTextHelpFormatter)
+            if command_parser:
+                renderer.print_command_help(
+                    command_parser.format_help(),
+                    title=f"noesis {command_name}",
+                )
+            return 0
+
+        # Full help screen
+        renderer.print_help(build_help_screen(ctx.version))
+        return 0
+
+
+HELP_COMMAND = HelpCommand()
+```
+
+---
+
+## 8. Tests
+
+### Registry Invariants
+
+```python
+# tests/cli/test_registry.py
+
+from noesis.cli.registry import REGISTRY, get_all_groups
+
+
+def test_registry_groups_are_valid():
+    """Every command has a valid group."""
+    valid_groups = set(get_all_groups())
+    for name, spec in REGISTRY.items():
+        assert spec.meta.group in valid_groups, f"{name} has invalid group: {spec.meta.group}"
+
+
+def test_home_commands_have_examples():
+    """Commands shown on home must have at least one example."""
+    for name, spec in REGISTRY.items():
+        if spec.meta.show_on_home:
+            assert spec.meta.examples, f"{name} is show_on_home but has no examples"
+
+
+def test_command_name_matches_key():
+    """Registry key must match command.name."""
+    for name, spec in REGISTRY.items():
+        assert spec.cmd.name == name, f"Key '{name}' != cmd.name '{spec.cmd.name}'"
+```
+
+### Home Screen Structure
+
+```python
+# tests/cli/test_home_help.py
+
+from noesis import cli
+from noesis.cli.registry import REGISTRY
+
+
+class TestHomeScreen:
+    def test_home_exits_zero(self):
+        assert cli.main([]) == 0
+
+    def test_home_has_quick_start(self, capsys):
+        cli.main([])
+        assert "Quick Start" in capsys.readouterr().out
+
+    def test_home_has_observe_section(self, capsys):
+        cli.main([])
+        out = capsys.readouterr().out
+        assert "Observe" in out or "ps" in out
+
+    def test_home_has_verify_section(self, capsys):
+        cli.main([])
+        out = capsys.readouterr().out
+        assert "Verify" in out or "artifacts" in out
+
+    def test_home_has_help_hint(self, capsys):
+        cli.main([])
+        assert "noesis help" in capsys.readouterr().out
+
+    def test_home_does_not_block(self, monkeypatch):
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        assert cli.main([]) == 0  # Does not hang
+
+    def test_home_json_exits_usage_error(self):
+        assert cli.main(["--json"]) == 2
+
+    def test_home_quiet_no_output(self, capsys):
+        cli.main(["--quiet"])
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestHelpScreen:
+    def test_help_exits_zero(self):
+        assert cli.main(["help"]) == 0
+
+    def test_help_has_all_groups(self, capsys):
+        cli.main(["help"])
+        out = capsys.readouterr().out
+        for group in ("Execute", "Observe", "Verify", "Maintain"):
+            assert group in out
+
+    def test_help_lists_all_commands(self, capsys):
+        cli.main(["help"])
+        out = capsys.readouterr().out
+        for name in REGISTRY:
+            assert name in out, f"Missing command: {name}"
+
+    def test_help_command_shows_usage(self, capsys):
+        cli.main(["help", "view"])
+        out = capsys.readouterr().out
+        assert "usage:" in out.lower()
+        assert "view" in out
+```
+
+### Breakpoint Layout
+
+```python
+# tests/cli/test_breakpoints.py
+
+import pytest
+from noesis.cli.theme import detect_breakpoint, Breakpoint
+
+
+@pytest.mark.parametrize("width,expected", [
+    (40, Breakpoint.COMPACT),
+    (59, Breakpoint.COMPACT),
+    (60, Breakpoint.STANDARD),
+    (80, Breakpoint.STANDARD),
+    (99, Breakpoint.STANDARD),
+    (100, Breakpoint.WIDE),
+    (120, Breakpoint.WIDE),
+    (200, Breakpoint.WIDE),
+])
+def test_breakpoint_detection(width, expected):
+    assert detect_breakpoint(width) == expected
+```
+
+### Renderer Selection Matrix
+
+```python
+# tests/cli/test_renderer_selection.py
+
+import pytest
+from noesis.cli.main import _select_renderer
+from noesis.cli.context import GlobalOptions
+from noesis.cli.render.plain import PlainRenderer
+
+
+class DummyCtx:
+    isatty = True
+
+
+class DummyCtxNoTTY:
+    isatty = False
+
+
+def test_no_color_forces_plain(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    r = _select_renderer(DummyCtx(), GlobalOptions())
+    assert isinstance(r, PlainRenderer)
+
+
+def test_json_forces_plain():
+    r = _select_renderer(DummyCtx(), GlobalOptions(json=True))
+    assert isinstance(r, PlainRenderer)
+
+
+def test_quiet_forces_plain():
+    r = _select_renderer(DummyCtx(), GlobalOptions(quiet=True))
+    assert isinstance(r, PlainRenderer)
+
+
+def test_non_tty_defaults_to_plain():
+    r = _select_renderer(DummyCtxNoTTY(), GlobalOptions())
+    assert isinstance(r, PlainRenderer)
+
+
+def test_force_rich_overrides_non_tty(monkeypatch):
+    pytest.importorskip("rich")
+    from noesis.cli.main import _HAS_RICH
+    if not _HAS_RICH:
+        pytest.skip("rich not installed")
+
+    from noesis.cli.render.richy import RichRenderer
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    r = _select_renderer(DummyCtxNoTTY(), GlobalOptions(force_rich=True))
+    assert isinstance(r, RichRenderer)
+```
+
+---
+
+## 9. Task List (PR Checklist)
+
+### Commit 1: Unified Registry
+```
+feat(cli): unify command registry with CommandSpec
+
+- Add CommandSpec = Command + CommandMeta
+- Create REGISTRY as single source of truth
+- Add query helpers: get_specs_by_group, get_home_specs
+- Maintain COMMANDS backward compat export
+
+Files: noesis/cli/registry.py
+Tests: test_registry_groups_are_valid, test_home_commands_have_examples, test_command_name_matches_key
+```
+
+### Commit 2: Theme Extensions
+```
+feat(cli): extend theme tokens and enforce box style
+
+- Add layout constants (max_width, gutter, indent)
+- Move Breakpoint + detect_breakpoint to theme.py
+- Add get_box_style() returning box.ROUNDED
+
+Files: noesis/cli/theme.py
+Tests: test_breakpoint_detection
+```
+
+### Commit 3: Content Builders
+```
+feat(cli): add content module derived from registry
+
+- Create noesis/cli/content/ with home.py, help.py
+- HomeScreen includes RecentEpisode support
+- Deprecate help_content.py
+
+Files: noesis/cli/content/__init__.py, home.py, help.py
+       noesis/cli/help_content.py (deprecation re-exports)
+```
+
+### Commit 4: Renderer Updates
+```
+feat(cli): update renderers for new home/help
+
+- Use box.ROUNDED everywhere (panels + tables)
+- Remove "Press Enter" blocking
+- Add RecentEpisodes panel to home
+- Command-specific help embeds argparse text
+
+Files: noesis/cli/render/plain.py, richy.py
+Tests: test_home_does_not_block
+```
+
+### Commit 5: Main Routing
+```
+feat(cli): route no-args to home with exit 0
+
+- Home screen returns 0 (not EXIT_USAGE)
+- --json with no command → exit 2, no output
+- Add _fetch_recent_episodes (summary-only fast path)
+
+Files: noesis/cli/main.py
+Tests: test_home_exits_zero, test_home_json_exits_usage_error
+```
+
+### Commit 6: Help Command
+```
+feat(cli): add dedicated help command
+
+- noesis help → full help screen
+- noesis help <cmd> → argparse text in styled panel
+- Register in unified REGISTRY
+
+Files: noesis/cli/commands/help.py, noesis/cli/registry.py
+Tests: test_help_exits_zero, test_help_lists_all_commands
+```
+
+### Commit 7: Tests
+```
+test(cli): add structural tests for home/help
+
+- Registry invariants
+- Home/help structure assertions
+- Breakpoint detection
+- Renderer selection matrix
+
+Files: tests/cli/test_registry.py, test_home_help.py, test_breakpoints.py, test_renderer_selection.py
+```
+
+---
+
+## 10. Definition of Done
+
+### Functional
+- [ ] `noesis` → home screen, exit 0
+- [ ] `noesis help` → grouped help, exit 0
+- [ ] `noesis help <cmd>` → argparse text styled, exit 0
+- [ ] `noesis --json` (no cmd) → exit 2, no output
+- [ ] No blocking interactions
+
+### Structural
+- [ ] Single `REGISTRY` is source of truth for commands + metadata
+- [ ] Content builders derive from registry
+- [ ] `box.ROUNDED` used across all Rich panels
+- [ ] Recent episodes reads summary.json only (fast path)
+
+### Quality
+- [ ] All existing tests pass
+- [ ] Registry invariant tests pass
+- [ ] Breakpoint detection tests pass
+- [ ] Renderer selection matrix tests pass
+- [ ] `lint-imports` passes
+
+### Documentation
+- [ ] CHANGELOG entry for exit code change (home = 0)

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -9,6 +9,41 @@ The Noēsis CLI is installed with the package. Run via `noesis` or `uv run noesi
 The CLI surface is intentionally small in this release. A more robust CLI is in active development, with better scripting ergonomics, richer subcommands, and stronger JSON-first workflows. When in doubt, treat `noesis <command> --help` as the source of truth.
 </Note>
 
+## Home screen and help
+
+Running `noesis` with no arguments shows a curated home screen instead of raw argparse output. It highlights a concise Quick Start, commonly used commands, and a next-step hint. When Rich is available and allowed, the home screen uses a premium, panel-based layout with a clear welcome header (similar to the demo look you shared).
+
+The CLI also ships an explicit `noesis help` command that prints the same grouped help view as `-h/--help` (Run / Inspect / Integrity / Maintenance), and can target a specific subcommand:
+
+```bash
+noesis help
+noesis help view
+```
+
+Home/help output respects `--json`, `--quiet`, `NO_COLOR`, and TTY detection. Use `--force-rich` or `NOESIS_FORCE_RICH=1` to enable Rich output in non-TTY contexts.
+
+**Home screen mockup (ASCII)**
+
+```text
+╭──────────────────────────────────────────────────────────────────────╮
+│  * Welcome to Noēsis                                                  │
+│  Cognitive episodes with observability and governance.                │
+╰──────────────────────────────────────────────────────────────────────╯
+  Quick Start
+    $ noesis run "Summarize this repo"
+    $ noesis solve react "Weekly plan"
+    $ noesis view <episode_id>
+
+  Most Used
+    $ noesis ps
+    $ noesis events <episode_id>
+    $ noesis artifacts verify <episode_id>
+
+  Next
+    → noesis help
+    → noesis <command> -h
+```
+
 ## Installation
 
 Install from source while the PyPI release is pending:
@@ -24,7 +59,7 @@ When PyPI is live, use `uv add noesis` or `pip install noesis`.
 
 ## Commands
 
-Available commands (in `noesis --help` order): `run`, `solve`, `list`, `show`, `events`, `insight`, `version`, `new`, `validate-ports`, `diagnostics`, `migrate`, `view`, `artifacts`.
+Available commands (in `noesis --help` order): `run`, `solve`, `list`, `show`, `events`, `insight`, `version`, `new`, `validate-ports`, `diagnostics`, `migrate`, `view`, `artifacts`, `ps`, `help`.
 
 ### noesis run
 
@@ -610,6 +645,8 @@ These options work with all commands:
 | `--verbose` | Verbose output (detailed reasoning) |
 | `--debug` | Debug mode (implies verbose) |
 | `--port NAME=SPEC` | Register a runtime port (repeatable) |
+| `--home` | Show the Noēsis home screen (even with a subcommand) |
+| `--force-rich` | Force Rich output even when stdout is not a TTY |
 | `--help` | Show help message |
 
 ## Environment variables
@@ -620,6 +657,8 @@ These options work with all commands:
 | `NOESIS_VERBOSE` | Verbose output (`true`/`false`, CLI output control) |
 | `NOESIS_DEBUG` | Debug output (`true`/`false`, implies verbose; CLI output control) |
 | `NO_COLOR` | Disable rich formatting when set (standard) |
+| `NOESIS_FORCE_RICH` | Force Rich output in non-TTY contexts |
+| `NOESIS_HOME` | Show the home screen (`true`/`false`) |
 | `NOESIS_RUNS_DIR` | Default runs directory |
 | `NOESIS_PLANNER` | Default planner mode (`meta`/`minimal`) |
 | `NOESIS_DIRECTION_MIN_CONFIDENCE` | Default `direction_min_confidence` |

--- a/noesis/cli/commands/base.py
+++ b/noesis/cli/commands/base.py
@@ -1,3 +1,8 @@
+"""Command protocol and base types.
+
+The canonical Command protocol is defined in noesis.cli.registry.
+This module re-exports it for backward compatibility.
+"""
 from __future__ import annotations
 
 import argparse
@@ -8,6 +13,8 @@ from ..render.base import OutputRenderer
 
 
 class Command(Protocol):
+    """Protocol for CLI commands."""
+
     name: str
     help: str
 

--- a/noesis/cli/commands/help.py
+++ b/noesis/cli/commands/help.py
@@ -1,0 +1,33 @@
+"""Help command: noesis help [command]"""
+from __future__ import annotations
+
+import argparse
+
+from ..context import CLIContext
+from ..render.base import OutputRenderer
+
+
+class HelpCommand:
+    name = "help"
+    help = "Show help for Noēsis or a specific command"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("command", nargs="?", help="Command name to show help for")
+
+    def run(self, args: argparse.Namespace, ctx: CLIContext, renderer: OutputRenderer) -> int:
+        # Lazy import to avoid circular dependency
+        from ..content.help import build_help_screen
+
+        if args.command:
+            from ..parser import build_command_parser
+
+            command_parser = build_command_parser(args.command, argparse.RawTextHelpFormatter)
+            if command_parser:
+                renderer.print_command_help(command_parser.format_help(), title=f"noesis {args.command}")
+                return 0
+            renderer.echo(f"Unknown command: {args.command}")
+        renderer.print_help(build_help_screen(ctx.version))
+        return 0
+
+
+COMMAND = HelpCommand()

--- a/noesis/cli/content/__init__.py
+++ b/noesis/cli/content/__init__.py
@@ -1,0 +1,17 @@
+"""Content builders for CLI screens, derived from the unified registry."""
+from .home import HomeScreen, QuickStartItem, CommandPreview, RecentEpisode, build_home_screen
+from .help import HelpScreen, CommandGroupInfo, CommandInfo, build_help_screen
+
+__all__ = [
+    # Home screen
+    "HomeScreen",
+    "QuickStartItem",
+    "CommandPreview",
+    "RecentEpisode",
+    "build_home_screen",
+    # Help screen
+    "HelpScreen",
+    "CommandGroupInfo",
+    "CommandInfo",
+    "build_help_screen",
+]

--- a/noesis/cli/content/help.py
+++ b/noesis/cli/content/help.py
@@ -1,0 +1,73 @@
+"""Help screen content model, derived from registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..registry import REGISTRY, get_specs_by_group, get_all_groups, GROUP_TITLES, CommandGroup
+
+
+@dataclass(frozen=True)
+class CommandInfo:
+    """Command info for help display."""
+
+    name: str
+    one_liner: str
+
+
+@dataclass(frozen=True)
+class CommandGroupInfo:
+    """A group of commands for help display."""
+
+    title: str
+    commands: tuple[CommandInfo, ...]
+
+
+@dataclass(frozen=True)
+class HelpScreen:
+    """Help screen content model."""
+
+    version: str
+    tagline: str
+    usage: str
+    groups: tuple[CommandGroupInfo, ...]
+    examples: tuple[str, ...]
+    footer: str
+
+
+def build_help_screen(version: str) -> HelpScreen:
+    """
+    Build help screen from registry metadata.
+
+    Args:
+        version: The Noēsis version string.
+
+    Returns:
+        A HelpScreen instance with all content derived from the registry.
+    """
+    groups = tuple(
+        CommandGroupInfo(
+            title=GROUP_TITLES[group],
+            commands=tuple(
+                CommandInfo(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+                for spec in get_specs_by_group(group)
+            ),
+        )
+        for group in get_all_groups()
+    )
+
+    # Collect first example from each command (up to 5)
+    examples: list[str] = []
+    for spec in REGISTRY.values():
+        if spec.meta.examples:
+            examples.append(spec.meta.examples[0])
+        if len(examples) >= 5:
+            break
+
+    return HelpScreen(
+        version=version,
+        tagline="Run, inspect, and govern cognitive episodes.",
+        usage="noesis <command> [options]",
+        groups=groups,
+        examples=tuple(examples),
+        footer="Tip: noesis help <command> or noesis <command> -h for details.",
+    )

--- a/noesis/cli/content/home.py
+++ b/noesis/cli/content/home.py
@@ -1,0 +1,102 @@
+"""Home screen content model, derived from registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..registry import REGISTRY, get_specs_by_group
+
+
+@dataclass(frozen=True)
+class QuickStartItem:
+    """A quick start example command with description."""
+
+    command: str
+    description: str
+
+
+@dataclass(frozen=True)
+class CommandPreview:
+    """A command preview for grouped display on home screen."""
+
+    name: str
+    one_liner: str
+
+
+@dataclass(frozen=True)
+class RecentEpisode:
+    """A recent episode for home screen preview (summary-only data)."""
+
+    time_str: str  # HH:MM
+    episode_short: str  # truncated ID (middle ellipsis)
+    status: str  # success | vetoed | error
+    task: str  # truncated task
+    duration: str  # e.g., "0.8s"
+
+
+@dataclass(frozen=True)
+class HomeScreen:
+    """Home screen content model."""
+
+    version: str
+    tagline: str
+    quick_start: tuple[QuickStartItem, ...]
+    recent_episodes: tuple[RecentEpisode, ...]
+    observe_commands: tuple[CommandPreview, ...]
+    verify_commands: tuple[CommandPreview, ...]
+    footer_hint: str
+
+
+def build_home_screen(
+    version: str,
+    *,
+    recent_episodes: Sequence[RecentEpisode] = (),
+) -> HomeScreen:
+    """
+    Build home screen from registry metadata.
+
+    Args:
+        version: The Noēsis version string.
+        recent_episodes: Optional list of recent episodes to display.
+
+    Returns:
+        A HomeScreen instance with all content derived from the registry.
+    """
+    # Quick start: curated set of commands with examples
+    quick_start_names = ["run", "ps", "view"]
+    quick_start = tuple(
+        QuickStartItem(
+            command=(
+                REGISTRY[name].meta.examples[0]
+                if REGISTRY[name].meta.examples
+                else f"noesis {name}"
+            ),
+            description=REGISTRY[name].meta.one_liner,
+        )
+        for name in quick_start_names
+        if name in REGISTRY
+    )
+
+    # Observe group (show_on_home only)
+    observe = tuple(
+        CommandPreview(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+        for spec in get_specs_by_group("observe")
+        if spec.meta.show_on_home
+    )
+
+    # Verify group (show_on_home only)
+    verify = tuple(
+        CommandPreview(name=spec.cmd.name, one_liner=spec.meta.one_liner)
+        for spec in get_specs_by_group("verify")
+        if spec.meta.show_on_home
+    )
+
+    return HomeScreen(
+        version=version,
+        tagline="Observable episodes · Governance · Deterministic replay",
+        quick_start=quick_start,
+        recent_episodes=tuple(recent_episodes),
+        observe_commands=observe,
+        verify_commands=verify,
+        footer_hint="noesis help",
+    )

--- a/noesis/cli/help_content.py
+++ b/noesis/cli/help_content.py
@@ -1,0 +1,46 @@
+"""DEPRECATED: Use noesis.cli.content instead.
+
+This module is a thin re-export for backward compatibility.
+All content builders are now derived from the unified registry.
+"""
+from __future__ import annotations
+
+# Re-export from new location for backward compatibility
+from .content.home import (
+    HomeScreen,
+    QuickStartItem,
+    CommandPreview,
+    RecentEpisode,
+    build_home_screen,
+)
+from .content.help import (
+    HelpScreen,
+    CommandGroupInfo,
+    CommandInfo,
+    build_help_screen,
+)
+
+# Legacy aliases for backward compatibility with existing code
+CommandGroup = CommandGroupInfo
+
+__all__ = [
+    # Home screen
+    "HomeScreen",
+    "QuickStartItem",
+    "CommandPreview",
+    "RecentEpisode",
+    "build_home_screen",
+    # Help screen
+    "HelpScreen",
+    "CommandGroup",  # Legacy alias
+    "CommandGroupInfo",
+    "CommandInfo",
+    "build_help_screen",
+]
+
+
+def iter_group_commands(groups):
+    """DEPRECATED: Iterate over commands in groups."""
+    for group in groups:
+        for command in group.commands:
+            yield command

--- a/noesis/cli/main.py
+++ b/noesis/cli/main.py
@@ -11,6 +11,9 @@ import noesis as ns
 from .context import GlobalOptions, build_context
 from .errors import EXIT_ERROR, EXIT_USAGE, EXIT_VETO
 from .render.plain import PlainRenderer
+from .content.home import build_home_screen
+from .content.help import build_help_screen
+from .theme import build_theme_tokens
 
 
 try:
@@ -24,7 +27,7 @@ except Exception:  # noqa: BLE001
     RichRenderer = None  # type: ignore[assignment]
     _HAS_RICH = False
 
-from .parser import build_parser
+from .parser import build_command_parser, build_parser
 from .registry import COMMANDS
 
 
@@ -52,38 +55,69 @@ def _select_renderer(ctx, options: GlobalOptions):
         return PlainRenderer(quiet=options.quiet)
     if not ctx.isatty and not options.force_rich:
         return PlainRenderer(quiet=options.quiet)
+    theme_tokens = build_theme_tokens()
     console = Console(
-        theme=Theme(
-            {
-                "title": "bold magenta",
-                "ok": "green",
-                "warn": "yellow",
-                "err": "bold red",
-                "muted": "dim",
-                "key": "cyan",
-                "val": "white",
-                "phase.start": "cyan",
-                "phase.intuition": "magenta",
-                "phase.observe": "bright_black",
-                "phase.interpret": "bright_blue",
-                "phase.plan": "bright_cyan",
-                "phase.direction": "blue",
-                "phase.insight": "green",
-                "phase.reason": "bright_black",
-                "phase.act": "white",
-                "phase.reflect": "green",
-                "phase.learn": "cyan",
-                "phase.terminate": "yellow",
-                "phase.error": "bold red",
-            }
-        ),
+        theme=Theme(theme_tokens.styles),
         force_terminal=options.force_rich,
         soft_wrap=True,
     )
     return RichRenderer(console, quiet=options.quiet)
 
 
+def _argv_has_flag(argv: Sequence[str], *flags: str) -> bool:
+    return any(token in flags for token in argv)
+
+
+def _detect_help_target(argv: Sequence[str]) -> Optional[str]:
+    if not _argv_has_flag(argv, "-h", "--help"):
+        return None
+    for token in argv:
+        if token in {"-h", "--help"}:
+            continue
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
+
+def _options_from_argv(argv: Sequence[str]) -> GlobalOptions:
+    env_force_rich = _env_bool("NOESIS_FORCE_RICH")
+    return GlobalOptions(
+        json=_argv_has_flag(argv, "-j", "--json"),
+        quiet=_argv_has_flag(argv, "-q", "--quiet"),
+        force_rich=_argv_has_flag(argv, "--force-rich") or bool(env_force_rich),
+    )
+
+
+def _render_home(renderer, ctx) -> None:
+    renderer.print_home(build_home_screen(ctx.version))
+
+
+def _render_help(renderer, ctx, *, command_name: str | None = None) -> None:
+    if command_name:
+        formatter = argparse.RawTextHelpFormatter
+        command = COMMANDS.get(command_name)
+        if not command:
+            renderer.print_help(build_help_screen(ctx.version))
+            renderer.echo(f"Unknown command: {command_name}")
+            return
+        command_parser = build_command_parser(command_name, formatter)
+        if command_parser:
+            renderer.print_command_help(command_parser.format_help(), title=f"noesis {command_name}")
+            return
+    renderer.print_help(build_help_screen(ctx.version))
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    help_target = _detect_help_target(raw_argv)
+    if help_target is not None:
+        options = _options_from_argv(raw_argv)
+        ctx = build_context(options, port_specs=[])
+        renderer = _select_renderer(ctx, options)
+        _render_help(renderer, ctx, command_name=help_target)
+        return 0
+
     formatter = _choose_formatter()
     parser, _ = build_parser(formatter)
     try:
@@ -91,19 +125,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     except SystemExit as exc:
         return exc.code
 
-    if not getattr(args, "command_obj", None):
-        parser.print_help()
-        return EXIT_USAGE
-
     env_compact = _env_bool("NOESIS_COMPACT")
     env_verbose = _env_bool("NOESIS_VERBOSE")
     env_debug = _env_bool("NOESIS_DEBUG")
     env_force_rich = _env_bool("NOESIS_FORCE_RICH")
+    env_home = _env_bool("NOESIS_HOME")
 
     compact_arg = getattr(args, "compact", None)
     verbose_arg = getattr(args, "verbose", None)
     debug_arg = getattr(args, "debug", None)
     force_rich_arg = getattr(args, "force_rich", None)
+    home_arg = getattr(args, "home", None)
 
     options = GlobalOptions(
         compact=compact_arg if compact_arg is not None else env_compact,
@@ -121,7 +153,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ctx = build_context(options, port_specs)
     renderer = _select_renderer(ctx, options)
 
-    command = args.command_obj
+    command = getattr(args, "command_obj", None)
+    home_requested = bool(home_arg) if home_arg is not None else bool(env_home)
+    if home_requested and not (options.json or options.quiet):
+        _render_home(renderer, ctx)
+        return 0 if command is not None else EXIT_USAGE
+
+    if command is None:
+        _render_home(renderer, ctx)
+        return 0
+
     provider = ns.session_provider()
     try:
         with provider.use(ctx.session):

--- a/noesis/cli/parser.py
+++ b/noesis/cli/parser.py
@@ -6,7 +6,7 @@ import noesis as ns
 from .registry import register_commands
 
 
-def _build_global_parser() -> argparse.ArgumentParser:
+def build_global_parser() -> argparse.ArgumentParser:
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument("--compact", action="store_true", default=None, help="Compact output (summary only)")
     global_parser.add_argument("--verbose", action="store_true", default=None, help="Verbose output (detailed reasoning)")
@@ -24,11 +24,17 @@ def _build_global_parser() -> argparse.ArgumentParser:
         metavar="NAME=SPEC",
         help="Register a runtime port (e.g. memory=acme.memory:FaissMemory(index_path='./mem'))",
     )
+    global_parser.add_argument(
+        "--home",
+        action="store_true",
+        default=None,
+        help="Show the Noēsis home screen (useful for demos)",
+    )
     return global_parser
 
 
 def build_parser(formatter_class: type[argparse.HelpFormatter]) -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
-    global_parser = _build_global_parser()
+    global_parser = build_global_parser()
     quick = "Quick start:\n  noesis run \"Summarize this repo\"\n  noesis solve react \"Weekly plan\"\n  noesis insight <episode_id> -j"
     cheat = (
         "Cheat sheet:\n"
@@ -56,3 +62,22 @@ def build_parser(formatter_class: type[argparse.HelpFormatter]) -> tuple[argpars
     sub = parser.add_subparsers(dest="command")
     register_commands(sub, parents=[global_parser], formatter_class=formatter_class)
     return parser, global_parser
+
+
+def build_command_parser(
+    command_name: str,
+    formatter_class: type[argparse.HelpFormatter],
+) -> argparse.ArgumentParser | None:
+    global_parser = build_global_parser()
+    from .registry import COMMANDS
+
+    cmd = COMMANDS.get(command_name)
+    if not cmd:
+        return None
+    parser = argparse.ArgumentParser(
+        prog=f"noesis {command_name}",
+        formatter_class=formatter_class,
+        parents=[global_parser],
+    )
+    cmd.add_arguments(parser)
+    return parser

--- a/noesis/cli/registry.py
+++ b/noesis/cli/registry.py
@@ -1,9 +1,72 @@
+"""Unified command registry: single source of truth for CLI commands and metadata."""
 from __future__ import annotations
 
 import argparse
-from typing import Dict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Literal, Protocol
 
-from .commands.base import Command
+if TYPE_CHECKING:
+    from .context import CLIContext
+    from .render.base import OutputRenderer
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PROTOCOLS & TYPES
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class Command(Protocol):
+    """Protocol for CLI commands."""
+
+    name: str
+    help: str
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None: ...
+
+    def run(self, args: argparse.Namespace, ctx: Any, renderer: Any) -> int: ...
+
+
+CommandGroup = Literal["execute", "observe", "verify", "maintain"]
+
+# Display order for groups
+GROUP_ORDER: tuple[CommandGroup, ...] = ("execute", "observe", "verify", "maintain")
+
+# Human-readable group titles
+GROUP_TITLES: dict[CommandGroup, str] = {
+    "execute": "Execute",
+    "observe": "Observe",
+    "verify": "Verify",
+    "maintain": "Maintain",
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMMAND METADATA
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CommandMeta:
+    """Presentation metadata for a command (used by home/help screens)."""
+
+    group: CommandGroup
+    one_liner: str
+    examples: tuple[str, ...] = ()
+    show_on_home: bool = False
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Unified command specification: execution logic + presentation metadata."""
+
+    cmd: Command
+    meta: CommandMeta
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMMAND IMPORTS
+# ─────────────────────────────────────────────────────────────────────────────
+
 from .commands.run import COMMAND as RUN_COMMAND
 from .commands.solve import COMMAND as SOLVE_COMMAND
 from .commands.list import COMMAND as LIST_COMMAND
@@ -18,24 +81,180 @@ from .commands.migrate import COMMAND as MIGRATE_COMMAND
 from .commands.view import COMMAND as VIEW_COMMAND
 from .commands.artifacts import COMMAND as ARTIFACTS_COMMAND
 from .commands.ps import COMMAND as PS_COMMAND
+from .commands.help import COMMAND as HELP_COMMAND
 
 
-COMMANDS: Dict[str, Command] = {cmd.name: cmd for cmd in (
-    RUN_COMMAND,
-    SOLVE_COMMAND,
-    LIST_COMMAND,
-    SHOW_COMMAND,
-    EVENTS_COMMAND,
-    INSIGHT_COMMAND,
-    VERSION_COMMAND,
-    NEW_COMMAND,
-    VALIDATE_COMMAND,
-    DIAGNOSTICS_COMMAND,
-    MIGRATE_COMMAND,
-    VIEW_COMMAND,
-    ARTIFACTS_COMMAND,
-    PS_COMMAND,
-)}
+# ─────────────────────────────────────────────────────────────────────────────
+# UNIFIED REGISTRY (single source of truth)
+# ─────────────────────────────────────────────────────────────────────────────
+
+REGISTRY: Dict[str, CommandSpec] = {
+    # ── Execute ──────────────────────────────────────────────────────────────
+    "run": CommandSpec(
+        cmd=RUN_COMMAND,
+        meta=CommandMeta(
+            group="execute",
+            one_liner="Run a baseline episode (no adapter)",
+            examples=('noesis run "Summarize this repo"',),
+            show_on_home=True,
+        ),
+    ),
+    "solve": CommandSpec(
+        cmd=SOLVE_COMMAND,
+        meta=CommandMeta(
+            group="execute",
+            one_liner="Run an episode with an adapter/flow",
+            examples=('noesis solve react "Weekly plan"',),
+        ),
+    ),
+    # ── Observe ──────────────────────────────────────────────────────────────
+    "ps": CommandSpec(
+        cmd=PS_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Show a compact table of recent episodes",
+            examples=("noesis ps", "noesis ps --limit 10"),
+            show_on_home=True,
+        ),
+    ),
+    "view": CommandSpec(
+        cmd=VIEW_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Inspect timeline, metrics, and governance",
+            examples=("noesis view <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "list": CommandSpec(
+        cmd=LIST_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="List recent episodes",
+            examples=("noesis list",),
+        ),
+    ),
+    "show": CommandSpec(
+        cmd=SHOW_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Show a single episode summary",
+            examples=("noesis show <episode_id>",),
+        ),
+    ),
+    "events": CommandSpec(
+        cmd=EVENTS_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Print or stream episode events",
+            examples=("noesis events <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "insight": CommandSpec(
+        cmd=INSIGHT_COMMAND,
+        meta=CommandMeta(
+            group="observe",
+            one_liner="Show computed insight metrics",
+            examples=("noesis insight <episode_id>",),
+        ),
+    ),
+    # ── Verify ───────────────────────────────────────────────────────────────
+    "artifacts": CommandSpec(
+        cmd=ARTIFACTS_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Manifest utilities and verification",
+            examples=("noesis artifacts verify <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    "validate-ports": CommandSpec(
+        cmd=VALIDATE_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Validate configured runtime ports",
+            examples=("noesis validate-ports",),
+        ),
+    ),
+    "diagnostics": CommandSpec(
+        cmd=DIAGNOSTICS_COMMAND,
+        meta=CommandMeta(
+            group="verify",
+            one_liner="Stability diagnostics and replay compare",
+            examples=("noesis diagnostics replay <episode_id>",),
+            show_on_home=True,
+        ),
+    ),
+    # ── Maintain ─────────────────────────────────────────────────────────────
+    "migrate": CommandSpec(
+        cmd=MIGRATE_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Codemod deprecated shims to the modern API",
+            examples=("noesis migrate --check",),
+        ),
+    ),
+    "version": CommandSpec(
+        cmd=VERSION_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Print CLI and core versions",
+            examples=("noesis version",),
+        ),
+    ),
+    "new": CommandSpec(
+        cmd=NEW_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Scaffold a starter flow or policy",
+            examples=("noesis new flow my_flow",),
+        ),
+    ),
+    "help": CommandSpec(
+        cmd=HELP_COMMAND,
+        meta=CommandMeta(
+            group="maintain",
+            one_liner="Show help for commands",
+            examples=("noesis help", "noesis help view"),
+        ),
+    ),
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BACKWARD COMPAT: COMMANDS dict for existing call sites
+# ─────────────────────────────────────────────────────────────────────────────
+
+COMMANDS: Dict[str, Command] = {name: spec.cmd for name, spec in REGISTRY.items()}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# QUERY HELPERS
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_specs_by_group(group: CommandGroup) -> list[CommandSpec]:
+    """Get all command specs in a group, sorted by name."""
+    return sorted(
+        [spec for spec in REGISTRY.values() if spec.meta.group == group],
+        key=lambda s: s.cmd.name,
+    )
+
+
+def get_home_specs() -> list[CommandSpec]:
+    """Get commands flagged for home screen display."""
+    return [spec for spec in REGISTRY.values() if spec.meta.show_on_home]
+
+
+def get_all_groups() -> tuple[CommandGroup, ...]:
+    """Get all group names in display order."""
+    return GROUP_ORDER
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ARGPARSE REGISTRATION
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 def register_commands(
@@ -44,7 +263,9 @@ def register_commands(
     parents: list[argparse.ArgumentParser],
     formatter_class: type[argparse.HelpFormatter],
 ) -> None:
-    for command in COMMANDS.values():
+    """Register all commands with argparse subparsers."""
+    for name, spec in REGISTRY.items():
+        command = spec.cmd
         parser = subparsers.add_parser(
             command.name,
             help=command.help,

--- a/noesis/cli/render/base.py
+++ b/noesis/cli/render/base.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Protocol
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Protocol
 
-from ..view_models import EpisodeDashboardVM
+if TYPE_CHECKING:
+    from ..view_models import EpisodeDashboardVM
+    from ..content.home import HomeScreen
+    from ..content.help import HelpScreen
 
 
 class OutputRenderer(Protocol):
@@ -18,6 +21,12 @@ class OutputRenderer(Protocol):
 
     def json(self, data: Any) -> None: ...
 
-    def print_viewer(self, view: EpisodeDashboardVM, *, grep: str | None = None) -> None: ...
+    def print_viewer(self, view: Any, *, grep: str | None = None) -> None: ...
 
     def print_ps(self, rows: Iterable[Dict[str, str]], *, quiet: bool = False) -> None: ...
+
+    def print_home(self, screen: Any) -> None: ...
+
+    def print_help(self, screen: Any) -> None: ...
+
+    def print_command_help(self, text: str, *, title: str | None = None) -> None: ...

--- a/noesis/cli/render/plain.py
+++ b/noesis/cli/render/plain.py
@@ -4,6 +4,7 @@ import json
 from typing import Dict, Iterable, Any, List
 
 from ..view_models import EpisodeDashboardVM, TimelineRowVM
+from ..help_content import HelpScreen, HomeScreen, CommandGroup
 
 from ..formatters import format_ps_rows_for_plain, format_rows_for_plain, format_duration, truncate
 
@@ -204,6 +205,80 @@ class PlainRenderer:
             for suggestion in view.suggestions:
                 print(f"  {suggestion}")
 
+    def print_home(self, screen: HomeScreen) -> None:
+        """Render home screen in plain mode."""
+        if self.quiet:
+            return
+
+        # Header
+        print(f"Noēsis {screen.version} — Cognitive Runtime CLI")
+        print(screen.tagline)
+        print()
+
+        # Quick Start
+        print("Quick Start")
+        for item in screen.quick_start:
+            print(f"  $ {item.command:<40} {item.description}")
+        print()
+
+        # Recent Episodes (if any)
+        if screen.recent_episodes:
+            print("Recent Episodes")
+            for ep in screen.recent_episodes[:5]:
+                print(f"  {ep.time_str}  {ep.episode_short:<12} {ep.status:<8} {ep.task[:30]}")
+            print()
+
+        # Command groups
+        print("Observe                           Verify")
+        max_rows = max(len(screen.observe_commands), len(screen.verify_commands), 1)
+        for i in range(max_rows):
+            obs = screen.observe_commands[i] if i < len(screen.observe_commands) else None
+            ver = screen.verify_commands[i] if i < len(screen.verify_commands) else None
+            obs_str = f"  {obs.name:<12} {obs.one_liner[:18]}" if obs else " " * 32
+            ver_str = f"  {ver.name:<16} {ver.one_liner[:20]}" if ver else ""
+            print(f"{obs_str}    {ver_str}")
+        print()
+
+        # Footer
+        print(f"→ {screen.footer_hint}")
+
+    def print_help(self, screen: HelpScreen) -> None:
+        """Render help screen in plain mode."""
+        if self.quiet:
+            return
+
+        # Header
+        print(f"Noēsis CLI {screen.version}")
+        print(screen.tagline)
+        print()
+        print(f"Usage: {screen.usage}")
+        print()
+
+        # Command groups
+        for group in screen.groups:
+            print(group.title)
+            max_name_len = max((len(cmd.name) for cmd in group.commands), default=0)
+            for cmd in group.commands:
+                print(f"  {cmd.name:<{max_name_len}}  {cmd.one_liner}")
+            print()
+
+        # Examples
+        print("Examples")
+        for example in screen.examples:
+            print(f"  $ {example}")
+        print()
+
+        # Footer
+        print(screen.footer)
+
+    def print_command_help(self, text: str, *, title: str | None = None) -> None:
+        if self.quiet:
+            return
+        if title:
+            print(f"{title}")
+            print("")
+        print(text.rstrip())
+
 
 def _chip(label: str, value: str | None) -> str:
     if not value:
@@ -221,6 +296,21 @@ def _format_ratio(value: float | None) -> str:
     if value is None:
         return "—"
     return f"{value:.2f}"
+
+
+def _print_section(title: str, items: Iterable[str]) -> None:
+    print(title)
+    for item in items:
+        print(f"  {item}")
+    print("")
+
+
+def _print_command_group(group: CommandGroup) -> None:
+    print(group.title)
+    max_len = max((len(cmd.name) for cmd in group.commands), default=0)
+    for cmd in group.commands:
+        print(f"  {cmd.name:<{max_len}}  {cmd.description}")
+    print("")
 
 
 def _render_table(

--- a/noesis/cli/render/richy.py
+++ b/noesis/cli/render/richy.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Dict, Iterable
+import sys
 
 from rich import box
 from rich.console import Console
+from rich.console import Group
+from rich.align import Align
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -14,32 +16,13 @@ from rich.syntax import Syntax
 
 from .. import formatters
 from ..view_models import EpisodeDashboardVM, TimelineRowVM
-
-
-# ---------------------------------------------------------------------------
-# Responsive Breakpoints (inspired by CSS media queries)
-# ---------------------------------------------------------------------------
-
-class Breakpoint(Enum):
-    """Terminal width breakpoints for adaptive layouts."""
-    COMPACT = "compact"    # < 60 cols  (mobile-like, single column)
-    STANDARD = "standard"  # 60-99 cols (typical split terminal)
-    WIDE = "wide"          # >= 100 cols (full-width terminal)
-
-
-# Breakpoint thresholds
-_COMPACT_MAX = 60
-_STANDARD_MAX = 100
+from ..help_content import HelpScreen, HomeScreen
+from ..theme import build_theme_tokens, Breakpoint, detect_breakpoint as _detect_breakpoint, get_box_style
 
 
 def detect_breakpoint(console: Console) -> Breakpoint:
     """Detect the current breakpoint based on console width."""
-    width = console.size.width
-    if width < _COMPACT_MAX:
-        return Breakpoint.COMPACT
-    if width < _STANDARD_MAX:
-        return Breakpoint.STANDARD
-    return Breakpoint.WIDE
+    return _detect_breakpoint(console.size.width)
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +118,7 @@ class RichRenderer:
     def __init__(self, console: Console, *, quiet: bool = False) -> None:
         self.console = console
         self.quiet = quiet
+        self._theme = build_theme_tokens()
 
     def banner(self, text: str) -> None:
         if not self.quiet:
@@ -154,14 +138,14 @@ class RichRenderer:
 
         table = Table(
             show_header=True,
-            header_style="bold magenta",
+            header_style="header",
             box=None,
             expand=True,
             pad_edge=False,
             row_styles=None,
         )
         table.add_column("STARTED_AT", style=_safe_style(self.console, "muted", "dim"), no_wrap=True, justify="right", max_width=25)
-        table.add_column("EPISODE_ID", style="bright_cyan", no_wrap=True, max_width=28)
+        table.add_column("EPISODE_ID", style=_safe_style(self.console, "accent", "bright_cyan"), no_wrap=True, max_width=28)
         table.add_column("TASK", style=_safe_style(self.console, "val", "white"))
         for row in rows:
             table.add_row(
@@ -181,13 +165,13 @@ class RichRenderer:
 
         table = Table(
             show_header=True,
-            header_style="bold magenta",
+            header_style="header",
             box=None,
             expand=True,
             pad_edge=False,
         )
         table.add_column("STARTED_AT", style=_safe_style(self.console, "muted", "dim"), no_wrap=True, max_width=20)
-        table.add_column("EPISODE", style="bright_cyan", no_wrap=True, max_width=12)
+        table.add_column("EPISODE", style=_safe_style(self.console, "accent", "bright_cyan"), no_wrap=True, max_width=12)
         table.add_column("STATUS", style=_safe_style(self.console, "val", "white"), no_wrap=True, max_width=8)
         table.add_column("USING", style=_safe_style(self.console, "muted", "dim"), no_wrap=True, max_width=14)
         table.add_column("DURATION", style=_safe_style(self.console, "val", "white"), no_wrap=True, max_width=10)
@@ -244,10 +228,11 @@ class RichRenderer:
         ):
             metrics_tbl.add_row(Text(key, style="key"), Text(str(metrics.get(key)), style="val"))
 
-        self.console.print(Panel(body, title=header, border_style="title"))
-        self.console.print(Panel(flags_tbl, title="[title]Flags[/]"))
-        self.console.print(Panel(dir_tbl, title="[title]Direction[/]"))
-        self.console.print(Panel(metrics_tbl, title="[title]Metrics[/]"))
+        border_style = _safe_style(self.console, "panel", "dim")
+        self.console.print(Panel(body, title=header, border_style=border_style))
+        self.console.print(Panel(flags_tbl, title="[title]Flags[/]", border_style=border_style))
+        self.console.print(Panel(dir_tbl, title="[title]Direction[/]", border_style=border_style))
+        self.console.print(Panel(metrics_tbl, title="[title]Metrics[/]", border_style=border_style))
 
     def print_events(self, events: Iterable[Dict[str, Any]]) -> None:
         for event in events:
@@ -318,7 +303,8 @@ class RichRenderer:
         header_body.add_row(header_grid)
         if chip_text.plain:
             header_body.add_row(Text(chip_text.plain, style="muted"))
-        self.console.print(Panel(header_body, border_style="title"))
+        border_style = _safe_style(self.console, "panel", "dim")
+        self.console.print(Panel(header_body, border_style=border_style))
 
     def _render_kpis_and_phases(self, vm: EpisodeDashboardVM, bp: Breakpoint) -> None:
         """Render KPIs and phase breakdown with adaptive layout."""
@@ -455,10 +441,127 @@ class RichRenderer:
         # On compact, show fewer suggestions
         suggestions_to_show = vm.suggestions[:2] if bp == Breakpoint.COMPACT else vm.suggestions
         suggestions = "\n".join(f"[muted]$[/] {item}" for item in suggestions_to_show)
-        self.console.print(Panel(suggestions, title="[title]Next[/]"))
+        border_style = _safe_style(self.console, "panel", "dim")
+        self.console.print(Panel(suggestions, title="[title]Next[/]", border_style=border_style))
 
     def print_viewer(self, view: EpisodeDashboardVM, *, grep: str | None = None) -> None:
         self.render_episode_dashboard(view, grep=grep)
+
+    def print_home(self, screen: HomeScreen) -> None:
+        """Render home screen in Rich mode."""
+        if self.quiet:
+            return
+
+        bp = detect_breakpoint(self.console)
+        box_style = get_box_style() or box.ROUNDED
+        border = _safe_style(self.console, "border", "grey42")
+
+        # Header panel
+        header_grid = Table.grid(expand=True)
+        header_grid.add_column(ratio=1)
+        header_grid.add_column(justify="right")
+        header_grid.add_row(
+            Text(f"Noēsis {screen.version}", style="title"),
+            Text("Cognitive Runtime CLI", style="muted"),
+        )
+        header_grid.add_row(Text(screen.tagline, style="home.tagline"))
+        self.console.print(Panel(header_grid, box=box_style, border_style=border))
+
+        # Quick Start panel
+        qs_body = "\n".join(
+            f"[muted]$[/] [nav.command]{item.command}[/]  [muted]{item.description}[/]"
+            for item in screen.quick_start
+        )
+        self.console.print(Panel(qs_body, title="[group.title]Quick Start[/]", box=box_style, border_style=border))
+
+        # Recent Episodes panel (if any)
+        if screen.recent_episodes:
+            ep_table = Table(box=None, show_header=False, expand=True, padding=(0, 1))
+            ep_table.add_column("time", style="muted", width=5)
+            ep_table.add_column("id", style="accent", width=12)
+            ep_table.add_column("status", width=7)
+            ep_table.add_column("task", style="val")
+            ep_table.add_column("dur", style="muted", justify="right", width=5)
+
+            for ep in screen.recent_episodes[:5]:
+                ep_table.add_row(
+                    ep.time_str,
+                    ep.episode_short,
+                    Text(ep.status, style=_status_style(ep.status)),
+                    formatters.truncate(ep.task, max_width=35),
+                    ep.duration,
+                )
+            self.console.print(Panel(ep_table, title="[group.title]Recent Episodes[/]", box=box_style, border_style=border))
+
+        # Command groups
+        observe_body = "\n".join(
+            f"[accent]{cmd.name:<12}[/] [muted]{cmd.one_liner}[/]"
+            for cmd in screen.observe_commands
+        )
+        verify_body = "\n".join(
+            f"[accent]{cmd.name:<14}[/] [muted]{cmd.one_liner}[/]"
+            for cmd in screen.verify_commands
+        )
+
+        observe_panel = Panel(observe_body, title="[group.title]Observe[/]", box=box_style, border_style=border)
+        verify_panel = Panel(verify_body, title="[group.title]Verify[/]", box=box_style, border_style=border)
+
+        if bp == Breakpoint.WIDE:
+            from rich.columns import Columns
+            self.console.print(Columns([observe_panel, verify_panel], expand=True))
+        else:
+            self.console.print(observe_panel)
+            self.console.print(verify_panel)
+
+        # Footer hint
+        self.console.print(Text(f"→ {screen.footer_hint}", style="nav.arrow"))
+
+    def print_help(self, screen: HelpScreen) -> None:
+        """Render help screen in Rich mode."""
+        if self.quiet:
+            return
+
+        box_style = get_box_style() or box.ROUNDED
+        border = _safe_style(self.console, "border", "grey42")
+
+        # Header
+        header_grid = Table.grid(padding=(0, 1))
+        header_grid.add_row(
+            Text(f"Noēsis CLI {screen.version}", style="title"),
+        )
+        header_grid.add_row(Text(screen.tagline, style="accent"))
+        header_grid.add_row(Text(f"Usage: {screen.usage}", style="muted"))
+        self.console.print(Panel(header_grid, box=box_style, border_style=border))
+
+        # Command groups
+        for group in screen.groups:
+            table = Table.grid(padding=(0, 1))
+            for cmd in group.commands:
+                table.add_row(Text(cmd.name, style="accent"), Text(cmd.one_liner, style="val"))
+            self.console.print(Panel(table, title=f"[group.title]{group.title}[/]", box=box_style, border_style=border))
+
+        # Examples
+        examples = "\n".join(f"[muted]$[/] {example}" for example in screen.examples)
+        self.console.print(Panel(examples, title="[group.title]Examples[/]", box=box_style, border_style=border))
+
+        # Footer
+        self.console.print(Text(screen.footer, style="hint"))
+
+    def print_command_help(self, text: str, *, title: str | None = None) -> None:
+        if self.quiet:
+            return
+        layout = self._theme.layout
+        body = Syntax(text.rstrip(), "text", word_wrap=True)
+        border_style = _safe_style(self.console, "panel", "dim")
+        self.console.print(
+            Panel(
+                body,
+                title=f"[title]{title}[/]" if title else None,
+                border_style=border_style,
+                padding=layout.panel_padding,
+                width=layout.panel_width,
+            )
+        )
 
 
 def _status_style(label: str) -> str:
@@ -504,3 +607,21 @@ def _phase_style(console: Console, phase: str) -> str:
     except Exception:  # noqa: BLE001 - rich raises errors for missing styles
         return "val"
     return style_name
+
+
+def _render_command_list(title: str, items: Iterable[str], *, bullet: str = "$", border_style: str = "dim") -> Panel:
+    body = "\n".join(f"[muted]{bullet}[/] {item}" for item in items)
+    return Panel(body, title=f"[title]{title}[/]", border_style=border_style)
+
+
+def _home_art() -> str:
+    return "\n".join(
+        (
+            "##   ##  ####   ######  ######  ##  ####",
+            "###  ## ##  ##  ##      ##      ## ##  ##",
+            "#### ## ##  ##  ####    ####    ## ##     ",
+            "## #### ##  ##  ##      ##      ## ##  ###",
+            "##  ### ##  ##  ##      ##      ## ##  ## ",
+            "##   ##  ####   ######  ######  ##  ####  ",
+        )
+    )

--- a/noesis/cli/theme.py
+++ b/noesis/cli/theme.py
@@ -1,0 +1,143 @@
+"""Theme tokens, layout constants, and breakpoints for CLI rendering."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BREAKPOINTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class Breakpoint(Enum):
+    """Terminal width breakpoints for adaptive layouts."""
+
+    COMPACT = "compact"  # < 60 cols (mobile-like, single column)
+    STANDARD = "standard"  # 60-99 cols (typical split terminal)
+    WIDE = "wide"  # >= 100 cols (full-width terminal)
+
+
+# Breakpoint thresholds
+COMPACT_MAX = 60
+STANDARD_MAX = 100
+
+
+def detect_breakpoint(width: int) -> Breakpoint:
+    """Detect breakpoint from terminal width."""
+    if width < COMPACT_MAX:
+        return Breakpoint.COMPACT
+    if width < STANDARD_MAX:
+        return Breakpoint.STANDARD
+    return Breakpoint.WIDE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LAYOUT CONSTANTS
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ThemeLayout:
+    """Layout constants for consistent spacing."""
+
+    panel_padding: tuple[int, int] = (1, 2)  # vertical, horizontal
+    panel_width: int = 88  # default panel width
+    max_width: int = 100  # cap for very wide terminals
+    min_width: int = 40  # minimum for compact mode
+    gutter: int = 2  # space between columns
+    indent: int = 2  # standard indent
+    command_col_width: int = 14  # command name column
+    description_col_width: int = 40  # description column
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THEME TOKENS
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ThemeTokens:
+    """Theme tokens for consistent styling."""
+
+    styles: Mapping[str, str]
+    layout: ThemeLayout = ThemeLayout()
+
+
+def build_theme_tokens() -> ThemeTokens:
+    """Build the complete theme token set."""
+    return ThemeTokens(
+        styles={
+            # ── Core text styles ─────────────────────────────────────────────
+            "title": "bold bright_cyan",
+            "accent": "bright_cyan",
+            "muted": "grey66",
+            "hint": "dim",
+            # ── Key-value pairs ──────────────────────────────────────────────
+            "key": "bright_cyan",
+            "val": "white",
+            # ── Status indicators ────────────────────────────────────────────
+            "ok": "green",
+            "warn": "yellow",
+            "err": "bold red",
+            # ── Structural elements ──────────────────────────────────────────
+            "border": "grey42",
+            "panel": "grey50",
+            "header": "bold bright_cyan",
+            # ── Badges ───────────────────────────────────────────────────────
+            "badge": "black on bright_cyan",
+            "badge.version": "black on bright_cyan",
+            "badge.success": "bold white on green",
+            "badge.warn": "bold black on yellow",
+            "badge.error": "bold white on red",
+            # ── Navigation ───────────────────────────────────────────────────
+            "nav.arrow": "bright_blue",
+            "nav.command": "bold bright_cyan",
+            # ── Group headers ────────────────────────────────────────────────
+            "group.title": "bold bright_cyan",
+            # ── Home screen ──────────────────────────────────────────────────
+            "home.tagline": "italic grey74",
+            "hero.badge": "bold white on blue",
+            "hero.art": "bright_blue",
+            "hero.prompt": "grey70",
+            "hero.accent": "bold bright_blue",
+            "hero.border": "blue",
+            # ── Phase colors (for timeline/events) ───────────────────────────
+            "phase.start": "cyan",
+            "phase.intuition": "magenta",
+            "phase.observe": "bright_black",
+            "phase.interpret": "bright_blue",
+            "phase.plan": "bright_cyan",
+            "phase.direction": "blue",
+            "phase.insight": "green",
+            "phase.reason": "bright_black",
+            "phase.act": "white",
+            "phase.reflect": "green",
+            "phase.learn": "cyan",
+            "phase.terminate": "yellow",
+            "phase.error": "bold red",
+        }
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ENFORCED STYLE: One border/box style everywhere
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_box_style():
+    """
+    Return the single box style used across all Rich panels/tables.
+
+    This enforces visual consistency: home panels, help panels, dashboard
+    tables, and all other Rich surfaces use the same border style.
+
+    Returns None if Rich is not available.
+    """
+    try:
+        from rich import box
+
+        return box.ROUNDED
+    except ImportError:
+        return None

--- a/tests/cli/test_breakpoints.py
+++ b/tests/cli/test_breakpoints.py
@@ -1,0 +1,70 @@
+"""Tests for theme breakpoint detection."""
+from __future__ import annotations
+
+import pytest
+
+from noesis.cli.theme import (
+    Breakpoint,
+    detect_breakpoint,
+    COMPACT_MAX,
+    STANDARD_MAX,
+    get_box_style,
+)
+
+
+class TestBreakpointDetection:
+    """Tests for terminal width breakpoint detection."""
+
+    @pytest.mark.parametrize(
+        "width,expected",
+        [
+            # Compact: < 60
+            (20, Breakpoint.COMPACT),
+            (40, Breakpoint.COMPACT),
+            (59, Breakpoint.COMPACT),
+            # Standard: 60-99
+            (60, Breakpoint.STANDARD),
+            (80, Breakpoint.STANDARD),
+            (99, Breakpoint.STANDARD),
+            # Wide: >= 100
+            (100, Breakpoint.WIDE),
+            (120, Breakpoint.WIDE),
+            (200, Breakpoint.WIDE),
+        ],
+    )
+    def test_detect_breakpoint(self, width: int, expected: Breakpoint):
+        """Breakpoint detection returns correct value for width."""
+        assert detect_breakpoint(width) == expected
+
+    def test_compact_max_threshold(self):
+        """COMPACT_MAX is the boundary between COMPACT and STANDARD."""
+        assert detect_breakpoint(COMPACT_MAX - 1) == Breakpoint.COMPACT
+        assert detect_breakpoint(COMPACT_MAX) == Breakpoint.STANDARD
+
+    def test_standard_max_threshold(self):
+        """STANDARD_MAX is the boundary between STANDARD and WIDE."""
+        assert detect_breakpoint(STANDARD_MAX - 1) == Breakpoint.STANDARD
+        assert detect_breakpoint(STANDARD_MAX) == Breakpoint.WIDE
+
+    def test_breakpoint_values_are_strings(self):
+        """Breakpoint enum values are human-readable strings."""
+        assert Breakpoint.COMPACT.value == "compact"
+        assert Breakpoint.STANDARD.value == "standard"
+        assert Breakpoint.WIDE.value == "wide"
+
+
+class TestBoxStyle:
+    """Tests for the enforced box style."""
+
+    def test_get_box_style_returns_rounded_when_rich_available(self):
+        """get_box_style returns box.ROUNDED when Rich is available."""
+        pytest.importorskip("rich")
+        from rich import box
+
+        result = get_box_style()
+        assert result is box.ROUNDED
+
+    def test_get_box_style_is_consistent(self):
+        """get_box_style always returns the same object."""
+        pytest.importorskip("rich")
+        assert get_box_style() is get_box_style()

--- a/tests/cli/test_home_help.py
+++ b/tests/cli/test_home_help.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+from noesis import cli
+
+
+def test_cli_home_plain(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOESIS_FORCE_RICH", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    code = cli.main([])
+    out = capsys.readouterr().out
+    assert code == 0  # no-args shows home and exits successfully
+    assert "Noēsis" in out
+    assert "Quick Start" in out
+    assert "Observe" in out
+    assert "Verify" in out
+
+
+def test_cli_home_rich(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("rich")
+    monkeypatch.setenv("NOESIS_FORCE_RICH", "1")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    code = cli.main([])
+    out = capsys.readouterr().out
+    assert code == 0  # no-args shows home and exits successfully
+    assert "Quick Start" in out
+
+
+def test_cli_help_groups(capsys) -> None:
+    code = cli.main(["help"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Execute" in out
+    assert "Observe" in out
+    assert "Verify" in out
+    assert "Maintain" in out
+    assert "Examples" in out
+
+
+def test_cli_help_command(capsys) -> None:
+    code = cli.main(["help", "view"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "usage:" in out.lower()
+    assert "--events" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Structural Tests: Content models derived from registry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHomeScreenStructure:
+    """Verify HomeScreen content is correctly derived from registry."""
+
+    def test_home_observe_commands_match_registry(self) -> None:
+        """Home screen observe commands match registry show_on_home flags."""
+        from noesis.cli.content.home import build_home_screen
+        from noesis.cli.registry import get_specs_by_group
+
+        screen = build_home_screen("test")
+        home_observe_names = {cmd.name for cmd in screen.observe_commands}
+
+        registry_observe_home = {
+            spec.cmd.name
+            for spec in get_specs_by_group("observe")
+            if spec.meta.show_on_home
+        }
+
+        assert home_observe_names == registry_observe_home
+
+    def test_home_verify_commands_match_registry(self) -> None:
+        """Home screen verify commands match registry show_on_home flags."""
+        from noesis.cli.content.home import build_home_screen
+        from noesis.cli.registry import get_specs_by_group
+
+        screen = build_home_screen("test")
+        home_verify_names = {cmd.name for cmd in screen.verify_commands}
+
+        registry_verify_home = {
+            spec.cmd.name
+            for spec in get_specs_by_group("verify")
+            if spec.meta.show_on_home
+        }
+
+        assert home_verify_names == registry_verify_home
+
+    def test_quick_start_uses_registry_examples(self) -> None:
+        """Quick start items use examples from registry metadata."""
+        from noesis.cli.content.home import build_home_screen
+        from noesis.cli.registry import REGISTRY
+
+        screen = build_home_screen("test")
+
+        for item in screen.quick_start:
+            # Command should contain a known command name
+            found_cmd = None
+            for name in REGISTRY:
+                if name in item.command:
+                    found_cmd = name
+                    break
+            assert found_cmd is not None, f"Quick start command '{item.command}' not in registry"
+
+            # Description should match registry one_liner
+            assert item.description == REGISTRY[found_cmd].meta.one_liner
+
+
+class TestHelpScreenStructure:
+    """Verify HelpScreen content is correctly derived from registry."""
+
+    def test_help_groups_match_registry_order(self) -> None:
+        """Help screen groups appear in registry GROUP_ORDER."""
+        from noesis.cli.content.help import build_help_screen
+        from noesis.cli.registry import get_all_groups, GROUP_TITLES
+
+        screen = build_help_screen("test")
+        help_group_titles = [g.title for g in screen.groups]
+
+        expected_titles = [GROUP_TITLES[g] for g in get_all_groups()]
+
+        assert help_group_titles == expected_titles
+
+    def test_help_contains_all_registry_commands(self) -> None:
+        """Help screen contains every command from registry."""
+        from noesis.cli.content.help import build_help_screen
+        from noesis.cli.registry import REGISTRY
+
+        screen = build_help_screen("test")
+        help_cmd_names = {
+            cmd.name for group in screen.groups for cmd in group.commands
+        }
+
+        registry_names = set(REGISTRY.keys())
+
+        assert help_cmd_names == registry_names
+
+    def test_help_one_liners_match_registry(self) -> None:
+        """Help screen one-liners match registry metadata."""
+        from noesis.cli.content.help import build_help_screen
+        from noesis.cli.registry import REGISTRY
+
+        screen = build_help_screen("test")
+
+        for group in screen.groups:
+            for cmd in group.commands:
+                registry_one_liner = REGISTRY[cmd.name].meta.one_liner
+                assert cmd.one_liner == registry_one_liner, (
+                    f"Mismatch for {cmd.name}: '{cmd.one_liner}' != '{registry_one_liner}'"
+                )
+
+    def test_help_examples_come_from_registry(self) -> None:
+        """Help screen examples are drawn from registry metadata."""
+        from noesis.cli.content.help import build_help_screen
+        from noesis.cli.registry import REGISTRY
+
+        screen = build_help_screen("test")
+
+        # Collect all examples from registry
+        all_registry_examples = set()
+        for spec in REGISTRY.values():
+            all_registry_examples.update(spec.meta.examples)
+
+        # Every help example should be in registry
+        for example in screen.examples:
+            assert example in all_registry_examples, (
+                f"Help example '{example}' not found in registry"
+            )

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -1,0 +1,100 @@
+"""Tests for the unified command registry invariants."""
+from __future__ import annotations
+
+import pytest
+
+from noesis.cli.registry import (
+    REGISTRY,
+    COMMANDS,
+    GROUP_ORDER,
+    get_specs_by_group,
+    get_home_specs,
+    get_all_groups,
+)
+
+
+class TestRegistryInvariants:
+    """Invariant tests to prevent registry drift."""
+
+    def test_registry_keys_match_command_names(self):
+        """Registry key must match the command's name attribute."""
+        for name, spec in REGISTRY.items():
+            assert spec.cmd.name == name, (
+                f"Registry key '{name}' does not match cmd.name '{spec.cmd.name}'"
+            )
+
+    def test_commands_dict_matches_registry(self):
+        """COMMANDS backward-compat dict must have same keys as REGISTRY."""
+        assert set(COMMANDS.keys()) == set(REGISTRY.keys())
+
+    def test_commands_dict_references_same_objects(self):
+        """COMMANDS[name] must be the same object as REGISTRY[name].cmd."""
+        for name, spec in REGISTRY.items():
+            assert COMMANDS[name] is spec.cmd
+
+    def test_all_groups_are_valid(self):
+        """Every command must have a valid group from GROUP_ORDER."""
+        valid_groups = set(GROUP_ORDER)
+        for name, spec in REGISTRY.items():
+            assert spec.meta.group in valid_groups, (
+                f"Command '{name}' has invalid group: {spec.meta.group}"
+            )
+
+    def test_home_commands_have_examples(self):
+        """Commands flagged show_on_home must have at least one example."""
+        for name, spec in REGISTRY.items():
+            if spec.meta.show_on_home:
+                assert spec.meta.examples, (
+                    f"Command '{name}' has show_on_home=True but no examples"
+                )
+
+    def test_all_commands_have_one_liner(self):
+        """Every command must have a non-empty one_liner."""
+        for name, spec in REGISTRY.items():
+            assert spec.meta.one_liner, (
+                f"Command '{name}' has empty one_liner"
+            )
+
+
+class TestQueryHelpers:
+    """Tests for registry query functions."""
+
+    def test_get_specs_by_group_returns_correct_commands(self):
+        """get_specs_by_group returns only commands from that group."""
+        for group in GROUP_ORDER:
+            specs = get_specs_by_group(group)
+            for spec in specs:
+                assert spec.meta.group == group
+
+    def test_get_specs_by_group_covers_all_commands(self):
+        """Every command is returned by exactly one group query."""
+        all_names = set()
+        for group in GROUP_ORDER:
+            specs = get_specs_by_group(group)
+            for spec in specs:
+                name = spec.cmd.name
+                assert name not in all_names, f"Command '{name}' in multiple groups"
+                all_names.add(name)
+
+        assert all_names == set(REGISTRY.keys())
+
+    def test_get_home_specs_returns_flagged_commands(self):
+        """get_home_specs returns only commands with show_on_home=True."""
+        home_specs = get_home_specs()
+        for spec in home_specs:
+            assert spec.meta.show_on_home is True
+
+    def test_get_home_specs_matches_filter(self):
+        """get_home_specs matches manual filtering."""
+        expected = [spec for spec in REGISTRY.values() if spec.meta.show_on_home]
+        actual = get_home_specs()
+        assert set(s.cmd.name for s in actual) == set(s.cmd.name for s in expected)
+
+    def test_get_all_groups_returns_group_order(self):
+        """get_all_groups returns the canonical GROUP_ORDER."""
+        assert get_all_groups() == GROUP_ORDER
+
+    def test_group_order_has_four_groups(self):
+        """GROUP_ORDER has exactly 4 groups."""
+        assert len(GROUP_ORDER) == 4
+        assert set(GROUP_ORDER) == {"execute", "observe", "verify", "maintain"}

--- a/tests/cli/test_renderer_selection.py
+++ b/tests/cli/test_renderer_selection.py
@@ -21,3 +21,20 @@ def test_force_rich_selects_rich_renderer(monkeypatch: pytest.MonkeyPatch) -> No
     renderer = _select_renderer(_DummyContext(), GlobalOptions(force_rich=True))
     assert isinstance(renderer, RichRenderer)
     assert not isinstance(renderer, PlainRenderer)
+
+
+def test_no_color_forces_plain_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    renderer = _select_renderer(_DummyContext(), GlobalOptions(force_rich=True))
+    assert isinstance(renderer, PlainRenderer)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+
+def test_json_forces_plain_renderer() -> None:
+    renderer = _select_renderer(_DummyContext(), GlobalOptions(json=True))
+    assert isinstance(renderer, PlainRenderer)
+
+
+def test_quiet_forces_plain_renderer() -> None:
+    renderer = _select_renderer(_DummyContext(), GlobalOptions(quiet=True))
+    assert isinstance(renderer, PlainRenderer)


### PR DESCRIPTION
## Summary
This PR modernizes the Noēsis CLI “first impression” and help experience so it feels like a real product surface in the terminal—while keeping runtime semantics unchanged.

### What changed
- **Registry is now the single source of truth**
  - Added `CommandSpec` + `CommandMeta` (group, one-liner, examples, show_on_home) and wired it so help/home content cannot drift from registered commands.
- **Home / Help UX is first-class**
  - `noesis` (no args) renders a themed **Home** screen and exits **0**.
  - Added `noesis help [command]` for a grouped help screen and command-specific help routing.
- **Adaptive CLI theming**
  - Added terminal breakpoints: **COMPACT (<60)**, **STANDARD (60–99)**, **WIDE (>=100)**.
  - Centralized box style selection via `get_box_style()` and enforced **box.ROUNDED** across Rich panels.
- **Renderer upgrades**
  - Rich + Plain renderers consume the same content models.
  - Removed any blocking interactions (no “Press Enter” behavior).
- **Docs + tests**
  - Updated CLI docs to reflect the new home/help UX.
  - Added structural tests for registry invariants, content derivation, breakpoints, and renderer selection.

### Behavior notes (intentional)
- `noesis` → Home screen, **exit 0**
- `noesis --quiet` (no command) → no output, **exit 0**
- `noesis --json` (no command) → usage error, **exit 2** (no output)
- Existing commands’ runtime behavior remains unchanged.

### Key files
- Registry: `noesis/cli/registry.py`, `noesis/cli/commands/base.py`
- Theme: `noesis/cli/theme.py`
- Content builders: `noesis/cli/content/*`, `noesis/cli/help_content.py` (compat shim)
- Renderers: `noesis/cli/render/plain.py`, `noesis/cli/render/richy.py`, `noesis/cli/render/base.py`
- Routing/help: `noesis/cli/main.py`, `noesis/cli/parser.py`, `noesis/cli/commands/help.py`
- Tests: `tests/cli/test_home_help.py`, `tests/cli/test_registry.py`, `tests/cli/test_breakpoints.py`, `tests/cli/test_renderer_selection.py`
- Docs: `docs/reference/cli.mdx`

### Follow-ups (optional)
- Add a small “Home screen” screenshot snippet to docs (Rich + Plain).
- Add a tiny benchmark assertion for home render time (<100ms) to guard regressions.