### PR TITLE
feat(adr-008): Governed actuator wiring in EpisodeRunner + deterministic ActionCandidate

### DIFF
--- a/noesis/usecases/actuation/candidate_builder.py
+++ b/noesis/usecases/actuation/candidate_builder.py
@@ -1,0 +1,96 @@
+"""
+Default action candidate builder for governed actuation.
+
+Builds deterministic action candidates from the current episode context without
+performing I/O or mutating state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import hashlib
+from typing import Any, Mapping, Sequence
+
+from noesis.domain.action_candidates import ActionCandidate, RedactionSpec
+from noesis.domain.planner.interfaces import EpisodeRequest
+from noesis.domain.state import NoesisState, PlanStep
+from noesis.usecases.actuation.governed_actuator import ActionCandidateBuilder
+
+_DEFAULT_REDACTION = RedactionSpec(
+    mode="hash_only",
+    policy_id="redact.default",
+    policy_version="1.0.0",
+    field_rules={},
+)
+
+
+@dataclass(slots=True)
+class DefaultActionCandidateBuilder(ActionCandidateBuilder):
+    """Constructs action candidates for adapter-backed execution."""
+
+    redaction: RedactionSpec = _DEFAULT_REDACTION
+
+    def build(
+        self,
+        *,
+        plan: Sequence[PlanStep],
+        request: EpisodeRequest,
+        state: NoesisState,
+    ) -> ActionCandidate:
+        step = plan[-1] if plan else None
+        payload: dict[str, Any] = {
+            "adapter_label": request.adapter_label,
+            "goal": request.goal,
+        }
+        if step:
+            payload["plan_step_id"] = step.id
+            payload["plan_step_kind"] = step.kind.value
+            payload["plan_step_description"] = step.description
+        provenance: Mapping[str, Any] | None = None
+        if step:
+            provenance = {"plan_step_id": step.id, "adapter": request.adapter_label}
+        return ActionCandidate(
+            id=None,
+            kind="adapter",
+            payload=payload,
+            state_ref="state.json",
+            state_hash=_hash_state(request=request, plan=plan, state=state),
+            redaction=self.redaction,
+            provenance=provenance,
+            risk_tags=(),
+        )
+
+
+def _hash_state(
+    *,
+    request: EpisodeRequest,
+    plan: Sequence[PlanStep],
+    state: NoesisState,
+) -> str:
+    snapshot = {
+        "episode_id": state.episode_id,
+        "seed": state.seed,
+        "task": state.task,
+        "adapter_label": request.adapter_label,
+        "plan": [
+            {"id": step.id, "kind": step.kind.value, "description": step.description}
+            for step in plan
+        ],
+    }
+    canonical = _canonical_dumps(snapshot).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _canonical_dumps(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+__all__ = ["DefaultActionCandidateBuilder"]

--- a/noesis/usecases/actuation/governed_actuator.py
+++ b/noesis/usecases/actuation/governed_actuator.py
@@ -154,8 +154,11 @@ class _ActionCandidateEventBus(EventBus):
 
 
 def _as_legacy_result(result: GovernedResult) -> ActuationResult:
+    status = result.status.value
+    if result.status is ActuationStatus.BLOCKED:
+        status = "vetoed"
     return ActuationResult(
-        status=result.status.value,
+        status=status,
         summary=result.summary,
         metrics=dict(result.metrics),
         reasons=list(result.reasons),

--- a/noesis/usecases/episode_runner.py
+++ b/noesis/usecases/episode_runner.py
@@ -40,6 +40,8 @@ from noesis.runtime.events_emitter import CognitiveEventEmitter
 from noesis.runtime.artifacts.ids import directive_uuid, governance_uuid
 from noesis.trace.events import read_events
 from noesis.runtime.normalization import normalize_using
+from noesis.usecases.actuation.candidate_builder import DefaultActionCandidateBuilder
+from noesis.usecases.actuation.governed_actuator import ActionCandidateBuilder, GovernedActuator
 from .hooks.meta_phase import CompositeMetaPhaseHook, MetaPhaseHook, NullMetaPhaseHook
 from .ports import (
     ClockPort,
@@ -107,6 +109,7 @@ class EpisodeDependencies:
     governance_timeout_ms: int | None = None
     intuition_policy: Intuition | None = None
     intuition_enabled: bool = False
+    action_candidate_builder: ActionCandidateBuilder | None = None
 
 
 @dataclass(slots=True)
@@ -131,7 +134,7 @@ class EpisodeRunner:
         *,
         instrumentation: EpisodeInstrumentation | None = None,
     ) -> None:
-        self._deps = deps
+        self._deps = self._wrap_actuator(deps)
         context = getattr(deps.state_repository, "context", None)
         if instrumentation is None:
             if context is None:
@@ -157,6 +160,24 @@ class EpisodeRunner:
         self._hooks = CompositeMetaPhaseHook(tuple(hooks))
         self._context = context
         self._prompt_recorder: PromptRecorderPort | None = instrumentation.prompt_recorder or getattr(context, "prompt_recorder", None)
+
+    def _wrap_actuator(self, deps: EpisodeDependencies) -> EpisodeDependencies:
+        if deps.governance_policy is None:
+            return deps
+        if deps.governance_mode is GovernanceMode.OFF:
+            return deps
+        if isinstance(deps.actuator, GovernedActuator):
+            return deps
+        builder = deps.action_candidate_builder or DefaultActionCandidateBuilder()
+        governed = GovernedActuator(
+            inner=deps.actuator,
+            candidate_builder=builder,
+            governance_policy=deps.governance_policy,
+            governance_mode=deps.governance_mode,
+            failure_policy=deps.governance_failure_policy,
+            timeout_ms=deps.governance_timeout_ms,
+        )
+        return replace(deps, actuator=governed)
 
     def run(self, request: EpisodeRequest) -> EpisodeResult:
         context = request.context
@@ -532,6 +553,11 @@ class EpisodeRunner:
             state=state,
             event_bus=self._deps.event_bus,
         )
+        if actuation.status == "vetoed" or (
+            actuation.status == "error" and "governance_failure" in actuation.reasons
+        ):
+            _ = self._clock.stop(token)
+            return actuation, None
         if governance_result and (
             governance_result.decision is GovernanceDecision.AUDIT
             or (governance_result.decision is GovernanceDecision.VETO and mode is GovernanceMode.AUDIT)

--- a/tests/usecases/test_candidate_builder.py
+++ b/tests/usecases/test_candidate_builder.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from noesis.domain.state import NoesisState, PlanKind, PlanStep
+from noesis.infrastructure.state_repository import EpisodeContext
+from noesis.usecases.actuation.candidate_builder import DefaultActionCandidateBuilder
+from noesis.usecases.episode_runner import EpisodeRequest
+
+
+def test_candidate_builder_state_hash_is_stable_across_plan_timestamps() -> None:
+    steps = [
+        PlanStep(id="step-1", kind=PlanKind.ACT, description="Execute task"),
+    ]
+    state_a = NoesisState(
+        episode_id="ep-1",
+        seed=0,
+        task="task",
+        started_at="2025-01-01T00:00:00Z",
+        tags={},
+        adapter_label="adapter:tooling",
+        plan_steps=list(steps),
+        plan_updated_at="2025-01-01T00:00:00Z",
+    )
+    state_b = NoesisState(
+        episode_id="ep-1",
+        seed=0,
+        task="task",
+        started_at="2025-01-01T00:00:00Z",
+        tags={},
+        adapter_label="adapter:tooling",
+        plan_steps=list(steps),
+        plan_updated_at="2030-01-01T00:00:00Z",
+    )
+    context = EpisodeContext(
+        run_dir=Path("."),
+        episode_id="ep-1",
+        seed=0,
+        task="task",
+        tags={},
+        adapter_label="adapter:tooling",
+        started_at="2025-01-01T00:00:00Z",
+    )
+    request = EpisodeRequest(goal="task", beliefs=(), context=context)
+    builder = DefaultActionCandidateBuilder()
+
+    candidate_a = builder.build(plan=steps, request=request, state=state_a)
+    candidate_b = builder.build(plan=steps, request=request, state=state_b)
+
+    assert candidate_a.state_hash == candidate_b.state_hash

--- a/tests/usecases/test_episode_runner_governed_actuator.py
+++ b/tests/usecases/test_episode_runner_governed_actuator.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from noesis.domain.faculties.governance import (
+    GovernanceDecision,
+    GovernanceFailurePolicy,
+    GovernanceMode,
+    GovernanceResult,
+    PreActGovernor,
+)
+from noesis.domain.planner.interfaces import ActuationResult, Actuator, Planner
+from noesis.domain.state import LineageTracker, NoesisState, PlanKind, PlanStep
+from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
+from noesis.interfaces.observability import RuntimeEventBus
+from noesis.runtime.clock import RuntimeClock
+from noesis.runtime.events_emitter import CognitiveEventEmitter
+from noesis.trace.events import read_events
+from noesis.usecases.episode_runner import EpisodeDependencies, EpisodeRequest, EpisodeRunner
+
+
+def _allow_result(goal: str) -> GovernanceResult:
+    return GovernanceResult(
+        decision=GovernanceDecision.ALLOW,
+        rule_id="rules.allow.test",
+        score=0.1,
+        message="",
+        policy_id="policy:test",
+        policy_version="1.0.0",
+        policy_kind="rules",
+        details={"goal": goal},
+    )
+
+
+class VetoActionGovernor(PreActGovernor):
+    policy_id = "policy:test"
+    policy_version = "1.0.0"
+    policy_kind = "rules"
+
+    def evaluate(self, *, goal, plan):  # type: ignore[no-untyped-def]
+        return _allow_result(goal)
+
+    def evaluate_action(self, *, goal, plan, action):  # type: ignore[no-untyped-def]
+        return GovernanceResult(
+            decision=GovernanceDecision.VETO,
+            rule_id="rules.veto.test",
+            score=0.9,
+            message="blocked",
+            policy_id=self.policy_id,
+            policy_version=self.policy_version,
+            policy_kind=self.policy_kind,
+            details={"goal": goal},
+        )
+
+
+class ErrorActionGovernor(PreActGovernor):
+    policy_id = "policy:test"
+    policy_version = "1.0.0"
+    policy_kind = "rules"
+
+    def evaluate(self, *, goal, plan):  # type: ignore[no-untyped-def]
+        return _allow_result(goal)
+
+    def evaluate_action(self, *, goal, plan, action):  # type: ignore[no-untyped-def]
+        raise RuntimeError("boom")
+
+
+class AllowActionGovernor(PreActGovernor):
+    policy_id = "policy:test"
+    policy_version = "1.0.0"
+    policy_kind = "rules"
+
+    def evaluate(self, *, goal, plan):  # type: ignore[no-untyped-def]
+        return _allow_result(goal)
+
+    def evaluate_action(self, *, goal, plan, action):  # type: ignore[no-untyped-def]
+        return _allow_result(goal)
+
+
+@dataclass(slots=True)
+class SingleStepPlanner(Planner):
+    def build_plan(self, *, goal: str, beliefs):  # type: ignore[no-untyped-def]
+        return [PlanStep(id="step-1", kind=PlanKind.ACT, description=f"Execute {goal}")]
+
+
+@dataclass(slots=True)
+class CountingActuator(Actuator):
+    called: int = 0
+
+    def execute(self, *, plan, request, state, event_bus):  # type: ignore[no-untyped-def]
+        self.called += 1
+        action = state.record_action(
+            kind="tool",
+            tool=request.context.adapter_label,
+            input_excerpt="run",
+            result_status="ok",
+            step_id=plan[-1].id if plan else None,
+        )
+        event_bus.emit_action(action)
+        return ActuationResult(
+            status="ok",
+            summary="done",
+            metrics={"success": 1.0},
+            reasons=[],
+            success=True,
+        )
+
+
+def _make_deps(
+    tmp_path: Path,
+    governor: PreActGovernor,
+    *,
+    failure_policy=None,
+    mode: GovernanceMode = GovernanceMode.ENFORCE,
+):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    context = EpisodeContext(
+        run_dir=run_dir,
+        episode_id="ep_gate",
+        seed=0,
+        task="safe",
+        tags={},
+        adapter_label="adapter:tooling",
+        started_at="2025-01-01T00:00:00Z",
+    )
+    state_repo = RuntimeStateRepository(context=context)
+    event_bus = RuntimeEventBus(
+        context=context,
+        emitter=CognitiveEventEmitter(run_dir=run_dir),
+        lineage=LineageTracker(),
+        clock=RuntimeClock(),
+    )
+    actuator = CountingActuator()
+    deps = EpisodeDependencies(
+        planner=SingleStepPlanner(),
+        actuator=actuator,
+        event_bus=event_bus,
+        state_repository=state_repo,
+        governance_policy=governor,
+        governance_mode=mode,
+        governance_failure_policy=failure_policy,
+    )
+    return deps, context, actuator
+
+
+def test_episode_runner_blocks_vetoed_action(tmp_path: Path) -> None:
+    deps, context, actuator = _make_deps(tmp_path, VetoActionGovernor())
+    runner = EpisodeRunner(deps)
+    request = EpisodeRequest(goal="safe", beliefs=(), context=context)
+    result = runner.run(request)
+
+    assert actuator.called == 0
+    assert result.outcome.status == "vetoed"
+    events = read_events(context.run_dir)
+    phases = [event.get("phase") for event in events]
+    assert "action_candidate" in phases
+    assert "governance" in phases
+    assert "act" not in phases
+
+
+def test_episode_runner_blocks_fail_closed_error(tmp_path: Path) -> None:
+    deps, context, actuator = _make_deps(
+        tmp_path,
+        ErrorActionGovernor(),
+        failure_policy=GovernanceFailurePolicy.FAIL_CLOSED,
+    )
+    runner = EpisodeRunner(deps)
+    request = EpisodeRequest(goal="safe", beliefs=(), context=context)
+    result = runner.run(request)
+
+    assert actuator.called == 0
+    assert result.outcome.status == "error"
+    assert "governance_failure" in result.outcome.reasons
+    events = read_events(context.run_dir)
+    phases = [event.get("phase") for event in events]
+    assert "action_candidate" in phases
+    assert "governance" in phases
+    assert "act" not in phases
+
+
+def test_episode_runner_allows_action_and_emits_lineage(tmp_path: Path) -> None:
+    deps, context, actuator = _make_deps(tmp_path, AllowActionGovernor())
+    runner = EpisodeRunner(deps)
+    request = EpisodeRequest(goal="safe", beliefs=(), context=context)
+    result = runner.run(request)
+
+    assert actuator.called == 1
+    assert result.outcome.status == "ok"
+    events = read_events(context.run_dir)
+    candidate_event = next(event for event in events if event.get("phase") == "action_candidate")
+    candidate_event_id = candidate_event["id"]
+    governance_event = next(
+        event for event in events if event.get("phase") == "governance" and event.get("caused_by") == candidate_event_id
+    )
+    act_event = next(
+        event
+        for event in events
+        if event.get("phase") == "act"
+        and event.get("payload", {}).get("action_candidate_id")
+        == candidate_event.get("payload", {}).get("action_candidate_id")
+    )
+    assert act_event.get("caused_by") == governance_event["id"]
+
+
+def test_episode_runner_audit_mode_allows_vetoed_action(tmp_path: Path) -> None:
+    deps, context, actuator = _make_deps(
+        tmp_path,
+        VetoActionGovernor(),
+        mode=GovernanceMode.AUDIT,
+    )
+    runner = EpisodeRunner(deps)
+    request = EpisodeRequest(goal="safe", beliefs=(), context=context)
+    result = runner.run(request)
+
+    assert actuator.called == 1
+    assert result.outcome.status == "ok"
+    events = read_events(context.run_dir)
+    phases = [event.get("phase") for event in events]
+    assert "action_candidate" in phases
+    assert "governance" in phases
+    assert "act" in phases

--- a/tests/usecases/test_governed_actuator.py
+++ b/tests/usecases/test_governed_actuator.py
@@ -121,7 +121,7 @@ def test_governed_actuator_blocks_on_veto(tmp_path: Path) -> None:
 
     result = governed.execute(plan=plan, request=request, state=state, event_bus=event_bus)
 
-    assert result.status == "blocked"
+    assert result.status == "vetoed"
     assert inner.called == 0
     events = read_events(context.run_dir)
     phases = [event.get("phase") for event in events]


### PR DESCRIPTION
## Summary

This PR completes the ADR-008 enforcement boundary by centralizing **pre-act governance gating** at Noēsis’ single side-effect boundary: **Actuator execution via `EpisodeRunner`**.

It introduces an **internal, deterministic `ActionCandidate` builder** (stable canonical JSON + `sha256:<64 hex>` state hash) and adds **EpisodeRunner-level integration tests** that validate **ALLOW / VETO / FAIL_CLOSED error** behavior through the governed boundary.

No public API changes; all additions remain internal and dependency-injected.

---

## Motivation

Noēsis governance can only enforce safety for actions it can see. ADR-008 requires a canonical mechanism to surface **pending side effects** *before* execution so ENFORCE mode can uphold the guarantee:

- **ENFORCE + VETO → no side effects occur**
- **ENFORCE + FAIL_CLOSED on governance error → status=error, not veto; no side effects occur**

Centralizing this behavior in `EpisodeRunner` prevents adapter-level drift and scales cleanly from a single agent to Fleet.

---

## Changes

### 1) EpisodeRunner governed boundary (no adapter hooks)
- Wrap the injected `Actuator` behind governance-on conditions inside:
  - `noesis/usecases/episode_runner.py`
- Preserve ADR-007 enforcement semantics:
  - Veto blocks execution (no act event).
  - FAIL_CLOSED governance error blocks execution (no act event), returns `status="error"`.

### 2) Deterministic default ActionCandidate builder (internal + injectable)
- Add:
  - `noesis/usecases/actuation/candidate_builder.py`
- Builder generates:
  - deterministic `ActionCandidate` payload
  - stable `state_hash` derived from a minimal snapshot (episode_id/seed/task/adapter_label/plan steps)
  - strict canonical JSON (`allow_nan=False`)

### 3) Governed actuator outcome alignment
- Map governed “blocked” to the existing outcome enum:
  - `ActuationStatus.BLOCKED → ActuationResult.status="vetoed"`
- Implemented in:
  - `noesis/usecases/actuation/governed_actuator.py`

### 4) Tests
- Add determinism coverage for the builder:
  - `tests/usecases/test_candidate_builder.py`
- Add EpisodeRunner integration tests for allow/veto/error paths:
  - `tests/usecases/test_episode_runner_governed_actuator.py`
- Update governed actuator tests for “vetoed” mapping:
  - `tests/usecases/test_governed_actuator.py`

---

## Non-goals

- No adapter-level gating hooks.
- No public re-exports / no API surface expansion.
- No fixture/golden refresh included here (handled after merge if needed).

---

## How to test

```bash
uv run pytest tests/usecases/test_candidate_builder.py -q
uv run pytest tests/usecases/test_episode_runner_governed_actuator.py -q
uv run pytest tests/usecases/test_governed_actuator.py -q