### PR TITLE
feat: expose ns.governed_act() as a public governed side-effect boundary (ADR-008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,37 @@ ns.set(planner_mode="minimal")   # opt out for throughput
 ns.run("Summarize release notes", intuition=False)
 ```
 
+Governed side effects (pre-act gating):
+
+ns.governed_act(...) is the “operating-system boundary” for side effects. It emits:
+	•	action_candidate → governance → act
+	•	or, on enforced veto: action_candidate → governance → terminate (no act)
+
+```python
+import noesis as ns
+from noesis.exceptions import NoesisVeto
+
+def run_shell(*, command: str, cwd: str | None = None, timeout_ms: int | None = None):
+    return {"stdout": "ok", "stderr": "", "exit_code": 0, "command": command}
+
+ns.set(shell_executor=run_shell)
+
+try:
+    result = ns.governed_act(
+        goal="List repository files",
+        kind="shell",
+        payload={
+            "command": "ls -a",
+            "cwd": ".",
+            "timeout_ms": 2000,
+        },
+    )
+    print(result)
+except NoesisVeto as veto:
+    # Raised only when governance is enforcing and the action is vetoed.
+    print(f"Blocked by governance: {veto.advice}")
+```
+
 ## Docs & links
 - Artifacts guide: `docs/artifacts/state.md`
 - Runs cheat sheet: `runs/README.md`

--- a/noesis/__init__.py
+++ b/noesis/__init__.py
@@ -18,6 +18,7 @@ from .runtime.determinism import DeterministicClock, DeterministicRNG
 from .direction import DirectedIntuition
 from .exceptions import NoesisVeto
 from .io import list_runs, last, paths
+from .api.governed_act import governed_act
 
 # Package metadata
 __version__ = "v1.0.0"
@@ -104,12 +105,16 @@ def set(*, context: Any | None = None, **overrides: object) -> None:
     """
     Apply config overrides for either a provided runtime context or the default session.
     """
+    from .runtime.actuation_registry import apply_actuation_overrides
+
+    overrides = apply_actuation_overrides(overrides)
     if context is not None:
         from .core import set as core_set
 
         core_set(context=context, **overrides)
         return
     _current_session().configure(**overrides)
+
 
 def get() -> dict[str, Any]:
     """Public accessor returning a mapping of the current runtime configuration."""
@@ -126,6 +131,7 @@ __all__ = (
     "solve",
     "set",
     "get",
+    "governed_act",
     # Session management
     "create_session",
     "session_provider",

--- a/noesis/_internal/__init__.py
+++ b/noesis/_internal/__init__.py
@@ -1,0 +1,3 @@
+"""Internal helpers not exported as part of the public API."""
+
+__all__ = []

--- a/noesis/_internal/actuation.py
+++ b/noesis/_internal/actuation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+from noesis.context import RuntimeContext
+
+
+def require_actuation_port(context: RuntimeContext):
+    """Return the configured actuation port or a default implementation."""
+    try:
+        return context.require("actuation", "actuation/1.0")
+    except Exception:
+        default_actuation = import_module("noesis.infrastructure.actuation.default_actuation")
+        return default_actuation.DefaultActuationPort()
+
+
+__all__ = ["require_actuation_port"]

--- a/noesis/api/governed_act.py
+++ b/noesis/api/governed_act.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Mapping, Sequence
+
+from noesis.context import RuntimeContext
+from noesis.exceptions import NoesisVeto
+
+
+def governed_act(
+    *,
+    goal: str,
+    kind: str,
+    payload: Mapping[str, Any],
+    seed: int = 0,
+    tags: Mapping[str, Any] | None = None,
+    context: Any | None = None,
+    provenance: Mapping[str, Any] | None = None,
+    risk_tags: Sequence[str] | None = None,
+    redaction: Mapping[str, Any] | None = None,
+) -> Any:
+    """Execute a governed action through the public API."""
+    runtime_context: RuntimeContext
+    merged_tags = tags
+    determinism = None
+    if context is None:
+        session_provider = import_module("noesis").session_provider
+        session = session_provider().current()
+        runtime_context = session.context
+        merged_tags = session.merge_tags(tags)
+        determinism = getattr(session, "determinism", None)
+    elif hasattr(context, "context") and hasattr(context, "merge_tags"):
+        session = context
+        runtime_context = session.context
+        merged_tags = session.merge_tags(tags)
+        determinism = getattr(session, "determinism", None)
+    else:
+        runtime_context = context
+
+    require_actuation_port = import_module("noesis._internal.actuation").require_actuation_port
+    port = require_actuation_port(runtime_context)
+    request_cls = import_module("noesis.interfaces.actuation").GovernedActRequest
+    request = request_cls(
+        goal=goal,
+        kind=kind,
+        payload=dict(payload),
+        seed=seed,
+        tags=dict(merged_tags) if merged_tags else None,
+        provenance=dict(provenance) if provenance else None,
+        risk_tags=tuple(risk_tags) if risk_tags else None,
+        redaction=dict(redaction) if redaction else None,
+        determinism=determinism,
+    )
+    try:
+        return port.governed_act(request, context=runtime_context)
+    except NoesisVeto:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        if _is_veto_like(exc):
+            raise _normalize_veto(exc, fallback_target=kind) from exc
+        raise
+
+
+__all__ = ["governed_act"]
+
+
+def _is_veto_like(exc: Exception) -> bool:
+    return hasattr(exc, "advice") or hasattr(exc, "scope")
+
+
+def _normalize_veto(exc: Exception, *, fallback_target: str) -> NoesisVeto:
+    return NoesisVeto(
+        advice=getattr(exc, "advice", str(exc)),
+        target=getattr(exc, "target", fallback_target),
+        scope=getattr(exc, "scope", "governance.pre_act"),
+        decision=getattr(exc, "decision", None),
+        rule_id=getattr(exc, "rule_id", None),
+        policy_id=getattr(exc, "policy_id", None),
+        policy_version=getattr(exc, "policy_version", None),
+        policy_kind=getattr(exc, "policy_kind", None),
+        enforced=getattr(exc, "enforced", None),
+        details=getattr(exc, "details", None),
+        error=getattr(exc, "error", None),
+        governance_id=getattr(exc, "governance_id", None),
+        action_candidate_id=getattr(exc, "action_candidate_id", None),
+    )

--- a/noesis/core.py
+++ b/noesis/core.py
@@ -113,9 +113,14 @@ def _load_graph(source: GraphSource) -> Any:
 # Public API
 
 def set(*, context: RuntimeContext | None = None, **overrides: Any) -> None:
+    from .runtime.actuation_registry import apply_actuation_overrides
+
     app = context or get_context()
+    remaining = apply_actuation_overrides(overrides)
+    if not remaining:
+        return
     config_port = app.require("config", getattr(app.config_port, "__api_version__", "config/1.0-rc1"))
-    config_port.set(**overrides)
+    config_port.set(**remaining)
 
 
 def solve(

--- a/noesis/exceptions.py
+++ b/noesis/exceptions.py
@@ -15,10 +15,36 @@ class NoesisError(Exception):
 
 
 class NoesisVeto(NoesisError):
-    """Raised when an intuition policy vetoes the episode."""
+    """Raised when a governance or intuition policy vetoes an action or episode."""
 
-    def __init__(self, *, advice: str, target: str, scope: str) -> None:
+    def __init__(
+        self,
+        *,
+        advice: str,
+        target: str,
+        scope: str,
+        decision: str | None = None,
+        rule_id: str | None = None,
+        policy_id: str | None = None,
+        policy_version: str | None = None,
+        policy_kind: str | None = None,
+        enforced: bool | None = None,
+        details: object | None = None,
+        error: object | None = None,
+        governance_id: str | None = None,
+        action_candidate_id: str | None = None,
+    ) -> None:
         super().__init__(advice)
         self.advice = advice
         self.target = target
         self.scope = scope
+        self.decision = decision
+        self.rule_id = rule_id
+        self.policy_id = policy_id
+        self.policy_version = policy_version
+        self.policy_kind = policy_kind
+        self.enforced = enforced
+        self.details = details
+        self.error = error
+        self.governance_id = governance_id
+        self.action_candidate_id = action_candidate_id

--- a/noesis/infrastructure/actuation/__init__.py
+++ b/noesis/infrastructure/actuation/__init__.py
@@ -1,0 +1,3 @@
+"""Infrastructure actuation implementations."""
+
+__all__ = []

--- a/noesis/infrastructure/actuation/default_actuation.py
+++ b/noesis/infrastructure/actuation/default_actuation.py
@@ -1,0 +1,431 @@
+"""
+Default governed actuation implementation.
+
+Uses ADR-008 action candidates + pre-act governance to control side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+from uuid import UUID, uuid4
+
+from noesis.context import RuntimeContext
+from noesis.domain.action_candidates import ActionCandidate, RedactionSpec
+from noesis.domain.faculties.governance import GovernanceMode, PreActGovernor
+from noesis.domain.state import LineageTracker, NoesisState
+from noesis.exceptions import NoesisVeto
+from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
+from noesis.interfaces.actuation import ActuationPort, GovernedActRequest
+from noesis.runtime.actuation_registry import get_actuation_registry
+from noesis.runtime.artifacts.ids import EpisodeIds, reset_ulid_state
+from noesis.runtime.artifacts.manifest import compute_sha256
+from noesis.runtime.artifacts.writer import ManifestWriter
+from noesis.runtime.clock import RuntimeClock
+from noesis.runtime.events import start_event as _start_event, terminate_event as _terminate_event
+from noesis.runtime.events_emitter import CognitiveEventEmitter
+from noesis.runtime.learning import ensure_learn_file
+from noesis.runtime.summary import finalize_summary as _finalize_summary
+from noesis.trace.schema import SUMMARY_SCHEMA_VERSION
+from noesis.usecases.action_gating import govern_pre_act_action
+from noesis.usecases.memory_sync import persist_episode_memory
+
+if True:  # typing-only imports without runtime overhead
+    from noesis.runtime.session.models import DeterminismConfig
+
+
+_DEFAULT_REDACTION = RedactionSpec(
+    mode="hash_only",
+    policy_id="redact.default",
+    policy_version="1.0.0",
+    field_rules={},
+)
+
+
+@dataclass(slots=True)
+class _GovernedActRuntime:
+    run_dir: Path
+    episode_id: str
+    started_at: str
+    event_id_factory: Callable[[], UUID]
+    now_fn: Callable[[], str]
+    clock: RuntimeClock
+    state_repo: RuntimeStateRepository
+    state: NoesisState
+    adapter_label: str
+
+
+class DefaultActuationPort(ActuationPort):
+    """Default actuation port for governed actions."""
+
+    __api_version__ = "actuation/1.0"
+
+    def governed_act(self, request: GovernedActRequest, *, context: RuntimeContext) -> Any:
+        return governed_act_impl(request=request, context=context)
+
+
+def governed_act_impl(*, request: GovernedActRequest, context: RuntimeContext) -> Any:
+    """
+    Execute a governed action with a deterministic action-candidate boundary.
+    """
+    registry = get_actuation_registry()
+    cfg = _config_snapshot(context)
+    determinism = getattr(request, "determinism", None)
+    runtime = _bootstrap_runtime(
+        request=request,
+        context=context,
+        determinism=determinism,
+        cfg=cfg,
+    )
+    candidate = _build_candidate(
+        kind=request.kind,
+        payload=request.payload,
+        provenance=request.provenance,
+        risk_tags=request.risk_tags,
+        redaction=request.redaction,
+        state_hash=_state_hash(runtime.run_dir),
+    )
+
+    gate = govern_pre_act_action(
+        goal=request.goal,
+        plan=(),
+        candidate=candidate,
+        event_bus=_event_bus(runtime),
+        episode_id=runtime.episode_id,
+        governance_policy=_resolve_policy(cfg.governance_mode, registry.governance_policy),
+        governance_mode=cfg.governance_mode,
+        failure_policy=cfg.governance_failure_policy,
+        timeout_ms=cfg.governance_timeout_ms,
+        caused_by=None,
+    )
+
+    if gate.terminal_outcome == "vetoed":
+        _finalize_terminal(
+            runtime=runtime,
+            context=context,
+            status="vetoed",
+            message=_governance_message(gate),
+        )
+        raise _veto_exception(gate, request.kind)
+
+    if gate.terminal_outcome == "error":
+        _finalize_terminal(
+            runtime=runtime,
+            context=context,
+            status="error",
+            message=_governance_message(gate),
+        )
+        raise RuntimeError("governance_failure")
+
+    executor = _resolve_executor(request.kind, registry)
+    result: Any | None = None
+    outcome = "ok"
+    error: Exception | None = None
+    try:
+        result = _invoke_executor(executor, request.payload)
+    except Exception as exc:  # noqa: BLE001
+        outcome = "error"
+        error = exc
+
+    action = runtime.state.record_action(
+        kind=request.kind,
+        tool=_resolve_tool_label(request.kind, request.payload, runtime.adapter_label),
+        input_excerpt=_input_excerpt(request.goal, request.payload),
+        result_status=outcome,
+        step_id=None,
+        extensions={"x-action_candidate_id": gate.candidate.id},
+    )
+    bus = _event_bus(runtime)
+    caused_by = gate.governance_event_id or gate.candidate_event_id
+    bus.emit_action(action, caused_by=caused_by)
+
+    status = "ok" if outcome == "ok" else "error"
+    _finalize_terminal(
+        runtime=runtime,
+        context=context,
+        status=status,
+        message=_message_for_status(request.goal, outcome, error),
+    )
+
+    if error is not None:
+        raise error
+    return result
+
+
+def _config_snapshot(context: RuntimeContext) -> Any:
+    config_port = context.require(
+        "config",
+        getattr(context.config_port, "__api_version__", "config/1.0-rc1"),
+    )
+    return config_port.get()
+
+
+def _bootstrap_runtime(
+    *,
+    request: GovernedActRequest,
+    context: RuntimeContext,
+    determinism: "DeterminismConfig | None",
+    cfg: Any,
+) -> _GovernedActRuntime:
+    ids = _mint_episode_ids(request.seed, determinism)
+    run_dir = _begin_episode(cfg.runs_dir, ids.episode_id)
+    clock, now_fn = _init_clock(determinism)
+    started_at = now_fn()
+    adapter_label = _resolve_adapter_label(request.kind, request.payload)
+    episode_ctx = EpisodeContext(
+        run_dir=run_dir,
+        episode_id=ids.episode_id,
+        seed=request.seed,
+        task=request.goal,
+        tags=dict(request.tags or {}),
+        adapter_label=adapter_label,
+        started_at=started_at,
+        prompt_provenance_enabled=getattr(cfg, "prompt_provenance_enabled", False),
+        prompt_provenance_mode=getattr(cfg, "prompt_provenance_mode", "hash_only"),
+    )
+    state_repo = RuntimeStateRepository(context=episode_ctx)
+    state = state_repo.init(episode_ctx)
+    event_id_factory = determinism.rng.event_id_factory(ids.directive_namespace) if determinism else uuid4
+    _start_event(
+        run_dir,
+        ids.episode_id,
+        {"task": request.goal, "seed": request.seed, "using": adapter_label},
+        now_fn=now_fn if determinism else None,
+        id_factory=event_id_factory,
+    )
+    return _GovernedActRuntime(
+        run_dir=run_dir,
+        episode_id=ids.episode_id,
+        started_at=started_at,
+        event_id_factory=event_id_factory,
+        now_fn=now_fn,
+        clock=clock,
+        state_repo=state_repo,
+        state=state,
+        adapter_label=adapter_label,
+    )
+
+
+def _event_bus(runtime: _GovernedActRuntime) -> "_RuntimeEventBus":
+    from noesis.interfaces.observability import RuntimeEventBus
+
+    episode_ctx = EpisodeContext(
+        run_dir=runtime.run_dir,
+        episode_id=runtime.episode_id,
+        seed=0,
+        task="",
+        tags={},
+        adapter_label=runtime.adapter_label,
+        started_at=runtime.started_at,
+    )
+    return RuntimeEventBus(
+        context=episode_ctx,
+        emitter=CognitiveEventEmitter(run_dir=runtime.run_dir),
+        lineage=LineageTracker(),
+        clock=runtime.clock,
+        now=_now_dt(runtime),
+        event_id_factory=runtime.event_id_factory,
+    )
+
+
+def _now_dt(runtime: _GovernedActRuntime) -> Callable[[], datetime]:
+    if isinstance(runtime.clock, RuntimeClock):
+        return lambda: datetime.now(timezone.utc)
+    return lambda: runtime.clock.now()  # type: ignore[return-value]
+
+
+def _state_hash(run_dir: Path) -> str:
+    return compute_sha256(run_dir / "state.json")
+
+
+def _build_candidate(
+    *,
+    kind: str,
+    payload: Mapping[str, Any],
+    provenance: Mapping[str, Any] | None,
+    risk_tags: Sequence[str] | None,
+    redaction: Mapping[str, Any] | None,
+    state_hash: str,
+) -> ActionCandidate:
+    redaction_spec = _parse_redaction(redaction)
+    return ActionCandidate(
+        id=None,
+        kind=kind,
+        payload=dict(payload),
+        state_ref="state.json",
+        state_hash=state_hash,
+        redaction=redaction_spec,
+        provenance=dict(provenance) if provenance else None,
+        risk_tags=tuple(risk_tags or ()),
+    )
+
+
+def _parse_redaction(redaction: Mapping[str, Any] | None) -> RedactionSpec:
+    if redaction is None:
+        return _DEFAULT_REDACTION
+    return RedactionSpec(
+        mode=str(redaction.get("mode", _DEFAULT_REDACTION.mode)),
+        policy_id=str(redaction.get("policy_id", _DEFAULT_REDACTION.policy_id)),
+        policy_version=str(redaction.get("policy_version", _DEFAULT_REDACTION.policy_version)),
+        field_rules=dict(redaction.get("field_rules") or {}),
+    )
+
+
+def _resolve_adapter_label(kind: str, payload: Mapping[str, Any]) -> str:
+    adapter_label = payload.get("adapter_label")
+    if isinstance(adapter_label, str) and adapter_label:
+        return adapter_label
+    return f"adapter:{kind}"
+
+
+def _resolve_tool_label(kind: str, payload: Mapping[str, Any], adapter_label: str) -> str:
+    tool = payload.get("tool")
+    if isinstance(tool, str) and tool:
+        return tool
+    return adapter_label or kind
+
+
+def _input_excerpt(goal: str, payload: Mapping[str, Any]) -> str:
+    if "command" in payload:
+        return str(payload.get("command", ""))[:120]
+    if "input_excerpt" in payload:
+        return str(payload.get("input_excerpt", ""))[:120]
+    if "cmd" in payload:
+        return str(payload.get("cmd", ""))[:120]
+    return str(goal)[:120]
+
+
+def _resolve_policy(mode: GovernanceMode, override: PreActGovernor | None) -> PreActGovernor | None:
+    if mode is GovernanceMode.OFF:
+        return None
+    return override or PreActGovernor()
+
+
+def _resolve_executor(kind: str, registry: Any) -> Callable[..., Any]:
+    if kind == "shell":
+        if registry.shell_executor is None:
+            raise ValueError("shell executor is not configured; call ns.set(shell_executor=...)")
+        return registry.shell_executor
+    if kind == "adapter":
+        if registry.adapter_executor is None:
+            raise ValueError("adapter executor is not configured; call ns.set(adapter_executor=...)")
+        return registry.adapter_executor
+    raise ValueError(f"unsupported action kind: {kind!r}")
+
+
+def _invoke_executor(executor: Callable[..., Any], payload: Mapping[str, Any]) -> Any:
+    try:
+        return executor(**dict(payload))
+    except TypeError:
+        return executor(payload)
+
+
+def _governance_message(gate: Any) -> str:
+    if gate.governance_result and gate.governance_result.message:
+        return gate.governance_result.message
+    return "Action blocked by governance"
+
+
+def _veto_exception(gate: Any, kind: str) -> NoesisVeto:
+    result = gate.governance_result
+    message = result.message if result else "Action vetoed"
+    return NoesisVeto(
+        advice=message,
+        target=kind,
+        scope="governance.pre_act",
+        decision=str(result.decision.value) if result else None,
+        rule_id=result.rule_id if result else None,
+        policy_id=result.policy_id if result else None,
+        policy_version=result.policy_version if result else None,
+        policy_kind=result.policy_kind if result else None,
+        enforced=bool(result.enforced) if result else None,
+        details=result.details if result else None,
+        error=result.error if result else None,
+        governance_id=str(result.governance_id) if result else None,
+        action_candidate_id=gate.candidate.id if gate.candidate else None,
+    )
+
+
+def _message_for_status(goal: str, outcome: str, error: Exception | None) -> str:
+    if outcome == "ok":
+        return f"Completed action for: {goal}"
+    return str(error) if error else "Action failed"
+
+
+def _finalize_terminal(
+    *,
+    runtime: _GovernedActRuntime,
+    context: RuntimeContext,
+    status: str,
+    message: str,
+) -> None:
+    runtime.state.set_outcome(status=status, summary=message, metrics={"success": 1.0 if status == "ok" else 0.0})
+    runtime.state_repo.persist(runtime.state)
+    _terminate_event(
+        runtime.run_dir,
+        runtime.episode_id,
+        {"status": status, "message": message},
+        now_fn=runtime.now_fn,
+        id_factory=runtime.event_id_factory,
+    )
+    _finalize_summary(
+        run_dir=runtime.run_dir,
+        episode_id=runtime.episode_id,
+        task=runtime.state.task,
+        seed=runtime.state.seed,
+        started_at=runtime.started_at,
+        intuition_enabled=False,
+        intuition_mode=runtime.state.intuition_mode,  # type: ignore[attr-defined]
+        using_label=runtime.adapter_label,
+        tags=runtime.state.tags,
+        intuition=None,
+        schema_version=SUMMARY_SCHEMA_VERSION,
+        config=_config_snapshot(context),
+        ports=context.list_ports(),
+    )
+    ensure_learn_file(runtime.run_dir)
+    persist_episode_memory(run_dir=runtime.run_dir, context=context)
+    _finalize_manifest(runtime.run_dir, runtime.episode_id)
+
+
+def _finalize_manifest(run_dir: Path, episode_id: str) -> None:
+    writer = ManifestWriter(run_dir=run_dir, episode_id=episode_id)
+    writer.finalize()
+    _ = compute_sha256(writer.manifest_path)
+
+
+def _begin_episode(runs_dir: Path, episode_id: str) -> Path:
+    from noesis.state.episode import begin_episode
+
+    return begin_episode(str(runs_dir), episode_id)
+
+
+def _mint_episode_ids(seed: int, determinism: "DeterminismConfig | None") -> EpisodeIds:
+    if determinism:
+        reset_ulid_state()
+        return EpisodeIds.mint(
+            seed=seed,
+            timestamp_ms=determinism.episode_timestamp_ms,
+            entropy=determinism.rng.bytes(10),
+        )
+    return EpisodeIds.mint(seed=seed)
+
+
+def _init_clock(
+    determinism: "DeterminismConfig | None",
+) -> tuple[RuntimeClock, Callable[[], str]]:
+    if determinism:
+        from noesis.runtime.determinism import DeterministicClock
+
+        run_clock = DeterministicClock(
+            start_at=determinism.clock.start_at,
+            tick_ms=determinism.clock.tick_ms,
+        )
+        return run_clock, lambda: run_clock.now().isoformat()
+    clock = RuntimeClock()
+    return clock, lambda: datetime.now(timezone.utc).isoformat()
+
+
+__all__ = ["DefaultActuationPort", "governed_act_impl"]

--- a/noesis/interfaces/actuation.py
+++ b/noesis/interfaces/actuation.py
@@ -1,0 +1,39 @@
+"""
+Actuation port contracts for governed side effects.
+
+These interfaces provide a stable boundary for executing side-effectful actions
+behind pre-act governance without exposing internal implementations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from noesis.context import RuntimeContext
+
+__all__ = ["ActuationPort", "GovernedActRequest"]
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedActRequest:
+    """Request payload for governed actuation."""
+
+    goal: str
+    kind: str
+    payload: Mapping[str, Any]
+    seed: int = 0
+    tags: Mapping[str, Any] | None = None
+    provenance: Mapping[str, Any] | None = None
+    risk_tags: tuple[str, ...] | None = None
+    redaction: Mapping[str, Any] | None = None
+    determinism: object | None = None
+
+
+class ActuationPort(Protocol):
+    """Port for executing governed actions."""
+
+    __api_version__: str = "actuation/1.0"
+
+    def governed_act(self, request: GovernedActRequest, *, context: RuntimeContext) -> Any:
+        """Execute a governed action and return the result."""

--- a/noesis/runtime/actuation_registry.py
+++ b/noesis/runtime/actuation_registry.py
@@ -1,0 +1,80 @@
+"""
+Runtime registry for governed actuation executors and governance overrides.
+
+This module keeps non-config runtime hooks (executors, custom governors) out of
+the domain/config layers while allowing public shims to configure them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from noesis.domain.faculties.governance import PreActGovernor
+
+Executor = Callable[..., Any]
+
+_ACTUATION_KEYS = frozenset({"shell_executor", "adapter_executor", "governance_policy"})
+
+
+@dataclass(slots=True)
+class ActuationRegistry:
+    """Holds executors used by the governed act boundary."""
+
+    shell_executor: Executor | None = None
+    adapter_executor: Executor | None = None
+    governance_policy: PreActGovernor | None = None
+
+
+_REGISTRY = ActuationRegistry()
+
+
+def apply_actuation_overrides(overrides: Mapping[str, object]) -> dict[str, object]:
+    """
+    Apply runtime-only overrides and return the remaining config overrides.
+    """
+    if not overrides:
+        return {}
+    remaining = dict(overrides)
+    for key in _ACTUATION_KEYS:
+        if key in remaining:
+            value = remaining.pop(key)
+            _set_registry_value(key, value)
+    return remaining
+
+
+def get_actuation_registry() -> ActuationRegistry:
+    """Return the current actuation registry."""
+    return _REGISTRY
+
+
+def _set_registry_value(key: str, value: object) -> None:
+    if key == "shell_executor":
+        _REGISTRY.shell_executor = _require_executor(value, key)
+        return
+    if key == "adapter_executor":
+        _REGISTRY.adapter_executor = _require_executor(value, key)
+        return
+    if key == "governance_policy":
+        _REGISTRY.governance_policy = _require_governor(value, key)
+        return
+    raise ValueError(f"Unsupported actuation override: {key}")
+
+
+def _require_executor(value: object, key: str) -> Executor | None:
+    if value is None:
+        return None
+    if callable(value):
+        return value
+    raise ValueError(f"{key} must be callable or None")
+
+
+def _require_governor(value: object, key: str) -> PreActGovernor | None:
+    if value is None:
+        return None
+    if isinstance(value, PreActGovernor):
+        return value
+    raise ValueError(f"{key} must be a PreActGovernor instance or None")
+
+
+__all__ = ["ActuationRegistry", "apply_actuation_overrides", "get_actuation_registry"]

--- a/noesis/runtime/session/session.py
+++ b/noesis/runtime/session/session.py
@@ -8,7 +8,7 @@ from noesis.context import RuntimeContext
 from noesis.interfaces.config import ConfigPort, ConfigSnapshot
 from noesis.intuition import Intuition
 
-from .models import SessionConfig
+from .models import SessionConfig, DeterminismConfig
 from .runner_port import RunnerProtocol, SessionRunRequest
 from .threading import SessionLock
 
@@ -31,6 +31,15 @@ class NoesisSession:
     @property
     def context(self) -> RuntimeContext:
         return self._context
+
+    @property
+    def determinism(self) -> DeterminismConfig | None:
+        """Expose deterministic instrumentation for callers that need it."""
+        return self._config.determinism
+
+    def merge_tags(self, tags: MutableMapping[str, Any] | None) -> dict[str, Any]:
+        """Merge tags with the session's defaults."""
+        return self._config.merge_tags(tags)
 
     def configure(self, **overrides: object) -> SessionConfig:
         """Apply config overrides and refresh the stored snapshot."""


### PR DESCRIPTION
## Summary

This PR introduces a new **public** API, `noesis.governed_act(...)`, which exposes ADR-008 “action candidates + pre-act governance gating” as a single, user-facing boundary for side effects.

External integrators can now do:
- `import noesis as ns`
- `ns.set(...)`
- `ns.governed_act(...)`
- `ns.run(...) / ns.solve(...)`

…without importing any internal modules.

## What changed
- Added **public** `ns.governed_act(...)` and exported it via `noesis/__init__.py`.
- Implemented a **strict public facade** that only resolves the runtime context and delegates to an internal actuation port.
- Added an internal actuation port contract (`ActuationPort`, `GovernedActRequest`) and a default internal implementation that reuses ADR-008 semantics.
- Exposed `NoesisSession.determinism` (read-only) to support deterministic IDs for governed actions.
- Expanded `NoesisVeto` diagnostics to preserve actionable policy metadata on enforced veto.
- Updated `README.md` with a doc-ready governed side effects example.

## Behavior / semantics (ADR-008)
The governed execution boundary produces the expected event ordering:
- **Allow path:** `action_candidate` → `governance` → `act`
- **Enforced veto path:** `action_candidate` → `governance` → `terminate` (and **no** `act`)

When governance is enforcing and the action is vetoed, `ns.governed_act(...)` raises `NoesisVeto`.

## Public API example
```python
import noesis as ns
from noesis.exceptions import NoesisVeto

def run_shell(*, command: str, cwd: str | None = None, timeout_ms: int | None = None):
    return {"stdout": "ok", "stderr": "", "exit_code": 0, "command": command}

ns.set(shell_executor=run_shell)

try:
    result = ns.governed_act(
        goal="List repository files",
        kind="shell",
        payload={"command": "ls -a", "cwd": ".", "timeout_ms": 2000},
    )
    print(result)
except NoesisVeto as veto:
    print(f"Blocked by governance: {veto.advice}")