### PR TITLE
fix(state): persist episode.intuition_mode to unblock governed_act finalization

### DIFF
--- a/noesis/core.py
+++ b/noesis/core.py
@@ -334,6 +334,7 @@ def _bootstrap_episode(
         tags=tags or {},
         adapter_label=adapter_label,
         started_at=ctx.started_at,
+        intuition_mode=cfg.intuition_mode,
         prompt_provenance_enabled=cfg.prompt_provenance_enabled,
         prompt_provenance_mode=cfg.prompt_provenance_mode,
     )

--- a/noesis/domain/state/models.py
+++ b/noesis/domain/state/models.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING
 import itertools
 
+if TYPE_CHECKING:
+    from noesis.domain.faculties.intuition import IntuitionMode
 
 STATE_VERSION = "1.0"
 STATE_SCHEMA_VERSION = "1.0.0"
@@ -20,6 +22,11 @@ STATE_SCHEMA_VERSION = "1.0.0"
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+def _default_intuition_mode() -> "IntuitionMode":
+    from noesis.domain.faculties.intuition import IntuitionMode
+
+    return IntuitionMode.ADVISORY
 
 
 class PlanKind(str, Enum):
@@ -189,6 +196,7 @@ class NoesisState:
     started_at: str
     tags: Dict[str, Any]
     adapter_label: str
+    intuition_mode: "IntuitionMode" = field(default_factory=_default_intuition_mode)
     plan_steps: List[PlanStep] = field(default_factory=list)
     plan_rationale: Optional[str] = None
     plan_source: str = "planner"
@@ -292,6 +300,7 @@ class NoesisState:
                 "started_at": self.started_at,
                 "tags": self.tags,
                 "using": self.adapter_label,
+                "intuition_mode": self.intuition_mode.value,
             },
             "goal": {"task": self.task, "type": "task"},
             "beliefs": list(self.beliefs),
@@ -361,8 +370,11 @@ def create_state(
     started_at: str,
     tags: Dict[str, Any],
     adapter_label: str,
+    intuition_mode: "IntuitionMode | None" = None,
 ) -> NoesisState:
     """Factory to instantiate a state with immutable metadata."""
+    if intuition_mode is None:
+        intuition_mode = _default_intuition_mode()
     return NoesisState(
         episode_id=episode_id,
         seed=seed,
@@ -370,4 +382,5 @@ def create_state(
         started_at=started_at,
         tags=tags,
         adapter_label=adapter_label,
+        intuition_mode=intuition_mode,
     )

--- a/noesis/infrastructure/actuation/default_actuation.py
+++ b/noesis/infrastructure/actuation/default_actuation.py
@@ -182,6 +182,7 @@ def _bootstrap_runtime(
         tags=dict(request.tags or {}),
         adapter_label=adapter_label,
         started_at=started_at,
+        intuition_mode=cfg.intuition_mode,
         prompt_provenance_enabled=getattr(cfg, "prompt_provenance_enabled", False),
         prompt_provenance_mode=getattr(cfg, "prompt_provenance_mode", "hash_only"),
     )
@@ -377,7 +378,7 @@ def _finalize_terminal(
         seed=runtime.state.seed,
         started_at=runtime.started_at,
         intuition_enabled=False,
-        intuition_mode=runtime.state.intuition_mode,  # type: ignore[attr-defined]
+        intuition_mode=runtime.state.intuition_mode,
         using_label=runtime.adapter_label,
         tags=runtime.state.tags,
         intuition=None,

--- a/noesis/infrastructure/state_repository.py
+++ b/noesis/infrastructure/state_repository.py
@@ -13,6 +13,7 @@ from typing import Literal, Protocol, TYPE_CHECKING
 
 from noesis.runtime.serialization import atomic_write_json
 from noesis.runtime.normalization import normalize_using
+from noesis.domain.faculties.intuition import IntuitionMode
 from noesis.domain.state import NoesisState, create_state
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class EpisodeContext:
     tags: dict[str, object]
     adapter_label: str
     started_at: str
+    intuition_mode: IntuitionMode = IntuitionMode.ADVISORY
     prompt_provenance_enabled: bool = False
     prompt_provenance_mode: Literal["full", "hash_only", "redacted"] = "hash_only"
     prompt_recorder: "PromptRecorder | None" = None
@@ -63,6 +65,7 @@ class RuntimeStateRepository(StateRepository):
             started_at=ctx.started_at,
             tags=ctx.tags,
             adapter_label=ctx.adapter_label,
+            intuition_mode=ctx.intuition_mode,
         )
         _write_state(path, state)
         self._state = state

--- a/tests/domain/state/test_state_models.py
+++ b/tests/domain/state/test_state_models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from noesis.domain.faculties.intuition import IntuitionMode
+from noesis.domain.state import create_state
+
+
+def test_create_state_sets_default_intuition_mode() -> None:
+    state = create_state(
+        episode_id="ep-1",
+        seed=0,
+        task="task",
+        started_at="2025-01-01T00:00:00Z",
+        tags={},
+        adapter_label="adapter:tooling",
+    )
+
+    assert state.intuition_mode is IntuitionMode.ADVISORY
+
+
+def test_create_state_accepts_intuition_mode() -> None:
+    state = create_state(
+        episode_id="ep-2",
+        seed=1,
+        task="task",
+        started_at="2025-01-02T00:00:00Z",
+        tags={},
+        adapter_label="adapter:tooling",
+        intuition_mode=IntuitionMode.INTERVENTIVE,
+    )
+
+    assert state.intuition_mode is IntuitionMode.INTERVENTIVE

--- a/tests/infrastructure/test_default_actuation.py
+++ b/tests/infrastructure/test_default_actuation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from noesis.context import create_runtime_context
+from noesis.domain.faculties.governance import GovernanceFailurePolicy, GovernanceMode
+from noesis.domain.faculties.intuition import IntuitionMode
+from noesis.domain.learning.model import LearnMode
+from noesis.infrastructure.actuation.default_actuation import governed_act_impl
+from noesis.interfaces.actuation import GovernedActRequest
+from noesis.interfaces.config import ConfigPort, ConfigSnapshot, PlannerMode
+from noesis.runtime.actuation_registry import get_actuation_registry
+
+
+class _StaticConfig(ConfigPort):
+    __api_version__ = "config/1.0-rc1"
+
+    def __init__(self, snapshot: ConfigSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def get(self) -> ConfigSnapshot:
+        return self._snapshot
+
+    def set(self, **overrides: object) -> ConfigSnapshot:
+        raise NotImplementedError
+
+    def reload(self) -> ConfigSnapshot:
+        return self._snapshot
+
+
+def _build_snapshot(runs_dir: Path, intuition_mode: IntuitionMode) -> ConfigSnapshot:
+    return ConfigSnapshot(
+        runs_dir=runs_dir,
+        agents="",
+        tasks="",
+        timeout_sec=30,
+        intuition_mode=intuition_mode,
+        direction_min_confidence=0.0,
+        planner_mode=PlannerMode.META,
+        policy_aliases={},
+        learn_mode=LearnMode.OFF,
+        learn_home=runs_dir,
+        learn_auto_apply_min_successes=0,
+        learn_auto_apply_min_confidence=0.0,
+        prompt_provenance_enabled=False,
+        prompt_provenance_mode="hash_only",
+        governance_mode=GovernanceMode.OFF,
+        governance_failure_policy=GovernanceFailurePolicy.FAIL_OPEN,
+        governance_timeout_ms=None,
+    )
+
+
+def _find_episode_dir(root: Path) -> Path:
+    candidates = [path for path in root.iterdir() if path.is_dir() and path.name.startswith("ep_")]
+    if not candidates:
+        raise AssertionError("no episode directories found")
+    return candidates[0]
+
+
+def test_governed_act_finalize_no_attribute_error(tmp_path: Path) -> None:
+    intuition_mode = IntuitionMode.INTERVENTIVE
+    snapshot = _build_snapshot(tmp_path, intuition_mode)
+    context = create_runtime_context(config_port=_StaticConfig(snapshot))
+
+    registry = get_actuation_registry()
+    previous_shell = registry.shell_executor
+    registry.shell_executor = lambda **_: "ok"
+    try:
+        result = governed_act_impl(
+            request=GovernedActRequest(
+                goal="touch file",
+                kind="shell",
+                payload={},
+                seed=0,
+                tags=None,
+                provenance=None,
+                risk_tags=None,
+                redaction=None,
+                determinism=None,
+            ),
+            context=context,
+        )
+    finally:
+        registry.shell_executor = previous_shell
+
+    assert result == "ok"
+
+    run_dir = _find_episode_dir(tmp_path)
+    state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
+    episode = state.get("episode", {})
+    assert episode.get("intuition_mode") == intuition_mode.value

--- a/tests/infrastructure/test_state_repository.py
+++ b/tests/infrastructure/test_state_repository.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from noesis.domain.faculties.intuition import IntuitionMode
+from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
+
+
+def test_state_repository_passes_intuition_mode(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    context = EpisodeContext(
+        run_dir=run_dir,
+        episode_id="ep-1",
+        seed=0,
+        task="task",
+        tags={},
+        adapter_label="adapter:tooling",
+        started_at="2025-01-01T00:00:00Z",
+        intuition_mode=IntuitionMode.HYBRID,
+    )
+    repo = RuntimeStateRepository(context=context)
+
+    state = repo.init(context)
+
+    assert state.intuition_mode is IntuitionMode.HYBRID


### PR DESCRIPTION
## Summary

This PR fixes an internal state contract mismatch where `governed_act` finalization expected
`runtime.state.intuition_mode` but the domain state schema did not define/persist it.
Result was an `AttributeError` during `_finalize_terminal` in default actuation.

## What changed

- **State contract:** Add `episode.intuition_mode` with a deterministic default (`IntuitionMode.ADVISORY`) and persist it in `state.json`.
- **State creation:** Thread configured `intuition_mode` through `EpisodeContext -> RuntimeStateRepository -> create_state` for both:
  - episode runs (`noesis/core.py`)
  - `governed_act` bootstrap (`noesis/infrastructure/actuation/default_actuation.py`)
- **Invariant:** Remove the `# type: ignore[attr-defined]` by making the state attribute real.

## Files touched

- `noesis/core.py`
- `noesis/domain/state/models.py`
- `noesis/infrastructure/actuation/default_actuation.py`
- `noesis/infrastructure/state_repository.py`
- `tests/domain/state/test_state_models.py`
- `tests/infrastructure/test_state_repository.py`
- `tests/infrastructure/test_default_actuation.py`

## Tests

- `uv run pytest` (252 passed, 1 skipped)

## Notes

- Field placement is under `episode.*` to match episode metadata semantics.
- Change is additive; existing consumers can ignore `episode.intuition_mode` if unknown.