### PR TITLE
verification(snapshot): add ADR-010 workspace snapshot primitive (domain/usecase/infra + tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Internal: Core orchestration split into `_run_minimal_episode` and `_run_adapter_episode` with shared finalization and runner-port wiring for determinism (behavior and artifacts unchanged).
 - Use-case ports added (`noesis/usecases/ports.py`) and `EpisodeRunner` refactored to depend on ports; import-linter contracts now enforce `usecases` isolation from adapters/CLI (ADR-006).
+- ADR-008: Action candidates and pre-act gating for governed actuation, with deterministic candidate lineage.
+- ADR-009: Dual sync/async execution model with `solve_async` and async adapter actuation, preserving sync semantics.
 
 ## v1.1.0 – 2025-12-08
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -214,6 +214,30 @@ Once these three conditions are met, the Noēsis runtime and artifact model are 
 
 ---
 
+### Phase 1.8 — Action Candidates (ADR-008 — DONE)
+
+**Focus:** Make side-effectful actions observable and governable before execution.
+
+**Delivered**
+
+- ActionCandidate data model and deterministic state hashing for pre-act gating (`domain/action_candidates.py`, `usecases/action_gating.py`).
+- Pre-act governance wiring for governed actuation with action-candidate lineage (`infrastructure/actuation/default_actuation.py`, `usecases/actuation/governed_actuator.py`).
+- Determinism fixtures covering allow/veto/fail-closed candidate flows (`tests/golden/adr_008/*`).
+
+---
+
+### Phase 1.9 — Dual Sync/Async Execution (ADR-009 — DONE)
+
+**Focus:** Add first-class async execution without changing sync semantics.
+
+**Delivered**
+
+- Async solve path with preserved invocation order and failure semantics (`core.solve_async`, `usecases/episode_runner.py`).
+- Async adapter actuator for awaitable results while keeping cognitive ownership in EpisodeRunner (`infrastructure/episode/adapter_actuator.py`).
+- Tests covering async callables, async invoke/run, and error semantics (`tests/runtime/test_async_solve.py`).
+
+---
+
 ### Phase 2 — NoesisSession GA (ADR-001 → Accepted; finalize GA proof)
 
 **Focus:** Make the session the public, deterministic entrypoint.

--- a/noesis/domain/snapshot.py
+++ b/noesis/domain/snapshot.py
@@ -1,0 +1,106 @@
+"""
+Workspace snapshot domain models and contracts.
+
+Architecture mapping:
+- Entities: Snapshot, WorkspaceDiff
+- Use Cases: SnapshotWorkspace (noesis/usecases/snapshot_workspace.py)
+- Interface Adapters: SnapshotGateway implementations
+- Infrastructure: FileSystemSnapshotGateway (noesis/infrastructure/snapshot/file_system_gateway.py)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
+
+DEFAULT_IGNORE: tuple[str, ...] = (".git", "__pycache__", ".venv", ".noesis")
+HASH_PREFIX = "sha256:"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceDiff:
+    """Deterministic diff between two workspace snapshots."""
+
+    added: list[str] = field(default_factory=list)
+    modified: list[str] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    """Immutable view of workspace files and their hashes."""
+
+    workspace_root: str
+    captured_at: str
+    files: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "files", dict(self.files))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable mapping with stable ordering."""
+        return {
+            "workspace_root": self.workspace_root,
+            "captured_at": self.captured_at,
+            "files": _sorted_mapping(self.files),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "Snapshot":
+        """Hydrate a snapshot from a JSON mapping."""
+        workspace_root = data.get("workspace_root")
+        captured_at = data.get("captured_at")
+        files = data.get("files")
+        if not isinstance(workspace_root, str) or not isinstance(captured_at, str):
+            raise ValueError("Snapshot mapping missing required string fields.")
+        if not isinstance(files, Mapping):
+            raise ValueError("Snapshot mapping missing files mapping.")
+        return cls(
+            workspace_root=workspace_root,
+            captured_at=captured_at,
+            files={str(key): str(value) for key, value in files.items()},
+        )
+
+    @staticmethod
+    def diff(pre: "Snapshot", post: "Snapshot") -> WorkspaceDiff:
+        """Return deterministic added/modified/deleted paths."""
+        pre_paths = set(pre.files.keys())
+        post_paths = set(post.files.keys())
+
+        added = sorted(post_paths - pre_paths)
+        deleted = sorted(pre_paths - post_paths)
+        modified = sorted(
+            path for path in (pre_paths & post_paths) if pre.files[path] != post.files[path]
+        )
+        return WorkspaceDiff(added=added, modified=modified, deleted=deleted)
+
+
+class SnapshotGateway(Protocol):
+    """Boundary for capturing and persisting workspace snapshots."""
+
+    def capture(self, workspace: Path, ignore: Sequence[str] = DEFAULT_IGNORE) -> Snapshot:
+        ...
+
+    def save(self, snapshot: Snapshot, path: Path) -> None:
+        ...
+
+    def load(self, path: Path) -> Snapshot:
+        ...
+
+
+class SnapshotCaptureError(RuntimeError):
+    """Raised when a snapshot capture fails due to IO issues."""
+
+
+def _sorted_mapping(data: Mapping[str, str]) -> dict[str, str]:
+    return {key: data[key] for key in sorted(data)}
+
+
+__all__ = [
+    "DEFAULT_IGNORE",
+    "HASH_PREFIX",
+    "Snapshot",
+    "SnapshotCaptureError",
+    "SnapshotGateway",
+    "WorkspaceDiff",
+]

--- a/noesis/infrastructure/snapshot/__init__.py
+++ b/noesis/infrastructure/snapshot/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure adapters for workspace snapshots."""
+
+__all__ = ["FileSystemSnapshotGateway"]
+
+from .file_system_gateway import FileSystemSnapshotGateway

--- a/noesis/infrastructure/snapshot/file_system_gateway.py
+++ b/noesis/infrastructure/snapshot/file_system_gateway.py
@@ -1,0 +1,80 @@
+"""Filesystem-backed snapshot capture and persistence."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from noesis.domain.snapshot import DEFAULT_IGNORE, HASH_PREFIX, Snapshot, SnapshotCaptureError
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _has_ignored_segment(relative_path: Path, ignore: Sequence[str]) -> bool:
+    return any(segment in ignore for segment in relative_path.parts)
+
+
+def _hash_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            hasher.update(chunk)
+    return f"{HASH_PREFIX}{hasher.hexdigest()}"
+
+
+def _iter_files(workspace: Path, ignore: Sequence[str]) -> Iterable[tuple[str, Path]]:
+    entries: list[tuple[str, Path]] = []
+    for path in workspace.rglob("*"):
+        if path.is_symlink():
+            continue
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(workspace)
+        if _has_ignored_segment(relative_path, ignore):
+            continue
+        entries.append((relative_path.as_posix(), path))
+    entries.sort(key=lambda item: item[0])
+    return entries
+
+
+@dataclass(slots=True)
+class FileSystemSnapshotGateway:
+    """Capture and persist workspace snapshots on the local filesystem."""
+
+    now: Callable[[], datetime] = field(default_factory=_utc_now)
+
+    def capture(self, workspace: Path, ignore: Sequence[str] = DEFAULT_IGNORE) -> Snapshot:
+        try:
+            files = {
+                rel_path: _hash_file(path) for rel_path, path in _iter_files(workspace, ignore)
+            }
+        except OSError as exc:
+            raise SnapshotCaptureError(f"snapshot_capture_failed: {exc}") from exc
+        captured_at = self.now().isoformat()
+        return Snapshot(
+            workspace_root=workspace.resolve().as_posix(),
+            captured_at=captured_at,
+            files=files,
+        )
+
+    def save(self, snapshot: Snapshot, path: Path) -> None:
+        payload = json.dumps(
+            snapshot.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+        path.write_text(payload, encoding="utf-8")
+
+    def load(self, path: Path) -> Snapshot:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return Snapshot.from_dict(data)
+
+
+__all__ = ["FileSystemSnapshotGateway"]

--- a/noesis/usecases/snapshot_workspace.py
+++ b/noesis/usecases/snapshot_workspace.py
@@ -1,0 +1,28 @@
+"""Use case for capturing workspace snapshots via a gateway."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from noesis.domain.snapshot import DEFAULT_IGNORE, Snapshot, SnapshotGateway
+
+
+@dataclass(slots=True)
+class SnapshotWorkspace:
+    """
+    Capture workspace snapshots using a gateway.
+
+    Integration note:
+    EpisodeRunner/solve will invoke this use case before and after Act to
+    persist pre/post snapshots into runs/<episode_id>/snapshots in a later PR.
+    """
+
+    gateway: SnapshotGateway
+
+    def capture(self, workspace: Path, ignore: Sequence[str] = DEFAULT_IGNORE) -> Snapshot:
+        """Capture a snapshot of the workspace using the configured gateway."""
+        return self.gateway.capture(workspace=workspace, ignore=ignore)
+
+
+__all__ = ["SnapshotWorkspace"]

--- a/tests/domain/test_snapshot.py
+++ b/tests/domain/test_snapshot.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from noesis.domain.snapshot import Snapshot
+
+
+def test_snapshot_diff_added_modified_deleted_sorted() -> None:
+    pre = Snapshot(
+        workspace_root="/workspace",
+        captured_at="2024-01-01T00:00:00Z",
+        files={
+            "b.txt": "sha256:bbb",
+            "a.txt": "sha256:aaa",
+            "d.txt": "sha256:ddd",
+        },
+    )
+    post = Snapshot(
+        workspace_root="/workspace",
+        captured_at="2024-01-01T00:00:01Z",
+        files={
+            "b.txt": "sha256:bbb-changed",
+            "c.txt": "sha256:ccc",
+        },
+    )
+
+    diff = Snapshot.diff(pre, post)
+
+    assert diff.added == ["c.txt"]
+    assert diff.modified == ["b.txt"]
+    assert diff.deleted == ["a.txt", "d.txt"]

--- a/tests/infrastructure/test_snapshot_gateway.py
+++ b/tests/infrastructure/test_snapshot_gateway.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+
+import pytest
+
+from noesis.domain.snapshot import SnapshotCaptureError
+from noesis.infrastructure.snapshot.file_system_gateway import FileSystemSnapshotGateway
+
+
+def _fixed_now() -> datetime:
+    return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_capture_is_deterministic_for_files_mapping(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_text(workspace / "a.txt", "alpha")
+    _write_text(workspace / "dir" / "b.txt", "bravo")
+
+    gateway = FileSystemSnapshotGateway(now=_fixed_now)
+    first = gateway.capture(workspace)
+    second = gateway.capture(workspace)
+
+    assert first.files == second.files
+
+
+def test_capture_ignores_segment_tokens(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_text(workspace / "keep.txt", "ok")
+    _write_text(workspace / ".git" / "config", "ignored")
+    _write_text(workspace / "__pycache__" / "skip.txt", "ignored")
+    _write_text(workspace / ".venv" / "skip.txt", "ignored")
+    _write_text(workspace / ".noesis" / "skip.txt", "ignored")
+    _write_text(workspace / "__init__" / "keep.txt", "ok")
+
+    gateway = FileSystemSnapshotGateway(now=_fixed_now)
+    snapshot = gateway.capture(workspace)
+
+    assert list(snapshot.files.keys()) == ["__init__/keep.txt", "keep.txt"]
+    assert list(snapshot.files.keys()) == sorted(snapshot.files.keys())
+
+
+def test_capture_skips_symlinks(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "target.txt"
+    target.write_text("data", encoding="utf-8")
+    link = workspace / "link.txt"
+
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    gateway = FileSystemSnapshotGateway(now=_fixed_now)
+    snapshot = gateway.capture(workspace)
+
+    assert "link.txt" not in snapshot.files
+    assert "target.txt" in snapshot.files
+
+
+def test_save_and_load_snapshot_round_trip(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_text(workspace / "a.txt", "alpha")
+
+    gateway = FileSystemSnapshotGateway(now=_fixed_now)
+    snapshot = gateway.capture(workspace)
+    path = tmp_path / "snapshot.json"
+
+    gateway.save(snapshot, path)
+    loaded = gateway.load(path)
+
+    assert snapshot.files == loaded.files
+    assert snapshot.workspace_root == loaded.workspace_root
+
+
+def test_capture_raises_snapshot_capture_error_on_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_text(workspace / "a.txt", "alpha")
+
+    gateway = FileSystemSnapshotGateway(now=_fixed_now)
+
+    def _raise_oserror(_: Path, __: int = 0) -> str:
+        raise OSError("nope")
+
+    monkeypatch.setattr(
+        "noesis.infrastructure.snapshot.file_system_gateway._hash_file",
+        _raise_oserror,
+    )
+
+    with pytest.raises(SnapshotCaptureError):
+        gateway.capture(workspace)


### PR DESCRIPTION
## Summary

This PR implements **PR-1** of **ADR-010**: the **workspace snapshot primitive** that enables deterministic, runtime-agnostic evidence capture for Noēsis verification.

It introduces a Clean Architecture-aligned snapshot module (domain + use case + filesystem gateway) with deterministic hashing/serialization, pytest coverage to verify determinism, ignore semantics, diff correctness, symlink skipping, save/load round-trips, and strict error propagation.

This PR is intentionally **snapshot-only**. Assertions, outcome wiring, summary schema changes, and CLI flags come in subsequent PRs.

---

## Motivation

Noēsis must distinguish:

- **adapter execution success** (no exception)
- vs
- **goal achieved** (evidence-based verification)

ADR-010 establishes **workspace snapshots** as the v0.1 foundation for that “judge” capability. This PR delivers the underlying primitive:

- capture `{relative_path -> sha256}`
- compute deterministic `{added, modified, deleted}` diffs
- persist snapshots under the episode directory later (wiring is out of scope in PR-1)

---

## What’s Included

### Clean Architecture modules

**Domain**
- `Snapshot` (immutable snapshot model)
- `WorkspaceDiff` (deterministic diff output)
- `SnapshotGateway` (boundary / interface)
- `SnapshotCaptureError` (strict capture failure semantics)
- ADR-010 defaults:
  - ignore tokens: `[".git", "__pycache__", ".venv", ".noesis"]`
  - symlinks: skip
  - hash: SHA-256
  - deterministic ordering

**Use Case**
- `SnapshotWorkspace` captures snapshots via injected gateway (no filesystem I/O)

**Infrastructure**
- `FileSystemSnapshotGateway`:
  - sorted POSIX relpaths for determinism
  - ignore-by-path-segment enforcement (ADR-010)
  - symlink skipping
  - **chunked hashing** for large files
  - propagates failures as `SnapshotCaptureError`
  - deterministic JSON save/load (stable separators + sorted keys)

---

## Tests

Pytest coverage locks the contract:

- deterministic capture (stable file mapping)
- ignore semantics (segment tokens)
- deterministic ordering of captured keys
- diff correctness (added/modified/deleted)
- symlink skipping (platform-gated)
- save/load round-trip stability
- strict error behavior (unreadable file -> SnapshotCaptureError)

---

## Module Structure
# PR Title

**verification(snapshot): add ADR-010 workspace snapshot primitive (domain/usecase/infra + tests)**

---

# PR Description

## Summary

This PR implements **PR-1** of **ADR-010**: the **workspace snapshot primitive** that enables deterministic, runtime-agnostic evidence capture for Noēsis verification.

It introduces a Clean Architecture-aligned snapshot module (domain + use case + filesystem gateway) with deterministic hashing/serialization and pytest coverage for determinism, ignore semantics, diff correctness, symlink skipping, save/load round-trips, and strict error propagation.

This PR is intentionally **snapshot-only**. Assertions, outcome wiring, summary schema changes, and CLI flags come in subsequent PRs.

---

## Motivation

Noēsis must distinguish:

- **adapter execution success** (no exception)
- vs
- **goal achieved** (evidence-based verification)

ADR-010 establishes **workspace snapshots** as the v0.1 foundation for that “judge” capability. This PR delivers the underlying primitive:

- capture `{relative_path -> sha256}`
- compute deterministic `{added, modified, deleted}` diffs
- persist snapshots under the episode directory later (wiring is out of scope in PR-1)

---

## What’s Included

### Clean Architecture modules

**Domain**
- `Snapshot` (immutable snapshot model)
- `WorkspaceDiff` (deterministic diff output)
- `SnapshotGateway` (boundary / interface)
- `SnapshotCaptureError` (strict capture failure semantics)
- ADR-010 defaults:
  - ignore tokens: `[".git", "__pycache__", ".venv", ".noesis"]`
  - symlinks: skip
  - hash: SHA-256
  - deterministic ordering

**Use Case**
- `SnapshotWorkspace` captures snapshots via injected gateway (no filesystem I/O)

**Infrastructure**
- `FileSystemSnapshotGateway`:
  - sorted POSIX relpaths for determinism
  - ignore-by-path-segment enforcement (ADR-010)
  - symlink skipping
  - **chunked hashing** for large files
  - propagates failures as `SnapshotCaptureError`
  - deterministic JSON save/load (stable separators + sorted keys)

---

## Tests

Pytest coverage locks the contract:

- deterministic capture (stable file mapping)
- ignore semantics (segment tokens)
- deterministic ordering of captured keys
- diff correctness (added/modified/deleted)
- symlink skipping (platform-gated)
- save/load round-trip stability
- strict error behavior (unreadable file -> SnapshotCaptureError)

---

## Module Structure

noesis/
domain/
snapshot.py
usecases/
snapshot_workspace.py
infrastructure/
snapshot/
init.py
file_system_gateway.py
tests/
domain/
test_snapshot.py
infrastructure/
test_snapshot_gateway.py

---

## Non-Goals (Explicit)

Per ADR-010 PR-1 scope, this PR does **not** include:

- assertion APIs (`file_contains`, `only_modified`, etc.)
- `ns.solve()` / `ns.solve_async()` wiring
- `summary.json` verification block
- CLI flags (`--workspace`, `--verify`)
- any governance / deep adapters / event schema changes

---

## Follow-ups

- **PR-2:** assertions (file_contains, file_exists, only_modified, no_modifications) + tests  
- **PR-3:** outcome wiring into `ns.solve()` + `summary.json` verification block  
- **PR-4:** CLI `run --workspace --verify` and `view` verification section  
- **PR-5:** demo fixture + screenshot + blog post wedge