### PR TITLE
chore: Include llm_real in offline replay datasets and fail fast on p…

### DIFF
--- a/tests/diagnostics/test_replay.py
+++ b/tests/diagnostics/test_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 
@@ -8,6 +9,26 @@ import pytest
 
 from noesis.artifacts import verify_manifest
 from noesis.diagnostics import compare_runs
+
+_PROVIDER_ENV_VARS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "MISTRAL_API_KEY",
+    "COHERE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_offline_env() -> None:
+    present = [name for name in _PROVIDER_ENV_VARS if os.getenv(name)]
+    if present:
+        pytest.fail(
+            "Offline replay tests require provider keys unset: "
+            + ", ".join(present)
+            + "."
+        )
 
 
 def _episode_dir(root: Path) -> Path:
@@ -21,6 +42,7 @@ def _episode_dir(root: Path) -> Path:
     [
         Path("tests/golden/deterministic_run"),
         Path("tests/golden/veto_enforce"),
+        Path("tests/golden/llm_real"),
         Path("tests/golden/adr_008/allow_enforce"),
         Path("tests/golden/adr_008/veto_enforce"),
         Path("tests/golden/adr_008/fail_closed_error"),
@@ -59,6 +81,7 @@ def test_compare_runs_surfaces_byte_drift(tmp_path: Path) -> None:
     [
         Path("tests/golden/deterministic_run"),
         Path("tests/golden/veto_enforce"),
+        Path("tests/golden/llm_real"),
         Path("tests/golden/adr_008/allow_enforce"),
         Path("tests/golden/adr_008/veto_enforce"),
         Path("tests/golden/adr_008/fail_closed_error"),


### PR DESCRIPTION
## Summary

- Added `tests/golden/llm_real` to both parametrized offline dataset lists in
  `tests/diagnostics/test_replay.py` (manifest verification + run diff comparison only).
- Added an offline guardrail in `tests/diagnostics/test_replay.py` that fails fast if
  any provider credentials are present:
  `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `MISTRAL_API_KEY`,
  `COHERE_API_KEY`, `AZURE_OPENAI_API_KEY`.

### Why
- Ensures the “real LLM” golden fixture participates in the same offline replay
  invariants as the deterministic and veto goldens.
- Prevents accidental network/provider usage from slipping into offline-only replay
  tests during future refactors.

### Tests
- `python scripts/replay_gate.py`
- `pytest -q tests/diagnostics/test_replay.py tests/cli/test_diagnostics_replay.py`