### PR TITLE
feat:Normalize workspace + verify inputs at public API boundary (PR4)

### DIFF
--- a/docs/reference/python-api.mdx
+++ b/docs/reference/python-api.mdx
@@ -28,6 +28,8 @@ episode_id = ns.run(
     intuition: bool | Intuition | None = True,
     tags: dict[str, object] | None = None,
     context: Any | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifySpec | Sequence[VerifySpec] | None = None,
 ) -> str
 ```
 
@@ -49,6 +51,14 @@ Metadata tags attached to the episode.
 
 <ParamField body="context" type="RuntimeContext" default="None">
 Optional runtime context. If provided, execution bypasses the default session.
+</ParamField>
+
+<ParamField body="workspace" type="str | Path | None" default="None">
+Workspace root to snapshot for verification.
+</ParamField>
+
+<ParamField body="verify" type="VerifySpec | Sequence[VerifySpec] | None" default="None">
+Verification assertions to evaluate against the workspace.
 </ParamField>
 
 **Returns**: Episode ID (e.g., `"ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C"`)
@@ -88,6 +98,8 @@ episode_id = ns.solve(
     intuition: bool | Intuition | None = True,
     tags: dict[str, object] | None = None,
     context: Any | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifySpec | Sequence[VerifySpec] | None = None,
 ) -> str
 ```
 
@@ -106,6 +118,26 @@ def to_upper(task: str) -> dict:
 
 episode_id = ns.solve("process this", using=to_upper)
 episode_id = ns.solve("process this", using="my.module:adapter_fn")
+```
+
+### Verification helpers
+
+Use these helpers to build verification specs for `verify=...`.
+
+```python
+verify = [
+    ns.file_exists("config.yaml"),
+    ns.file_contains("config.yaml", "enabled: true"),
+    ns.only_modified(["config.yaml"]),
+    ns.no_modifications(),
+]
+
+episode_id = ns.solve(
+    "Update config",
+    using="my.module:adapter_fn",
+    workspace=".",
+    verify=verify,
+)
 ```
 
 ### ns.summary.read()

--- a/noesis/__init__.py
+++ b/noesis/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from pathlib import Path
 from typing import Any, Dict, Optional
 from warnings import warn
 
@@ -19,6 +20,15 @@ from .direction import DirectedIntuition
 from .exceptions import NoesisVeto
 from .io import list_runs, last, paths
 from .api.governed_act import governed_act
+from .verification import (
+    VerifyInput,
+    VerifySpec,
+    file_contains,
+    file_exists,
+    no_modifications,
+    normalize_verify,
+    only_modified,
+)
 
 # Package metadata
 __version__ = "v1.0.0"
@@ -51,8 +61,12 @@ def run(
     intuition: bool | Intuition | None = True,
     tags: Optional[Dict[str, Any]] = None,
     context: Any | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
 ) -> str:
     """Execute a task using the default session (planner derived from config)."""
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_spec = normalize_verify(verify)
     if context is not None:
         from .core import run as core_run
 
@@ -62,12 +76,16 @@ def run(
             intuition=intuition,
             tags=tags,
             context=context,
+            workspace=workspace_path,
+            verify=verify_spec,
         )
     return _current_session().run(
         task,
         seed=seed,
         intuition=intuition,
         tags=tags,
+        workspace=workspace_path,
+        verify=verify_spec,
     )
 
 
@@ -79,8 +97,12 @@ def solve(
     intuition: bool | Intuition | None = True,
     tags: Optional[Dict[str, Any]] = None,
     context: Any | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
 ) -> str:
     """Execute a task using an explicit graph/adapter."""
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_spec = normalize_verify(verify)
     if context is not None:
         from .core import run_using as core_run_using
 
@@ -91,6 +113,8 @@ def solve(
             intuition=intuition,
             tags=tags,
             context=context,
+            workspace=workspace_path,
+            verify=verify_spec,
         )
     return _current_session().solve(
         using=using,
@@ -98,6 +122,8 @@ def solve(
         seed=seed,
         intuition=intuition,
         tags=tags,
+        workspace=workspace_path,
+        verify=verify_spec,
     )
 
 
@@ -109,8 +135,12 @@ async def solve_async(
     intuition: bool | Intuition | None = True,
     tags: Optional[Dict[str, Any]] = None,
     context: Any | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
 ) -> str:
     """Execute a task using an explicit graph/adapter (async)."""
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_spec = normalize_verify(verify)
     if context is not None:
         from .core import solve_async as core_solve_async
 
@@ -121,6 +151,8 @@ async def solve_async(
             intuition=intuition,
             tags=tags,
             context=context,
+            workspace=workspace_path,
+            verify=verify_spec,
         )
     return await _current_session().solve_async(
         using=using,
@@ -128,6 +160,8 @@ async def solve_async(
         seed=seed,
         intuition=intuition,
         tags=tags,
+        workspace=workspace_path,
+        verify=verify_spec,
     )
 
 
@@ -176,6 +210,14 @@ __all__ = (
     "DirectedIntuition",
     "Intuition",
     "NoesisVeto",
+    # Verification helpers
+    "VerifyInput",
+    "VerifySpec",
+    "file_contains",
+    "file_exists",
+    "no_modifications",
+    "normalize_verify",
+    "only_modified",
     # Read/introspection API
     "list_runs",
     "last",

--- a/noesis/core.py
+++ b/noesis/core.py
@@ -61,6 +61,7 @@ from .usecases.episode_runner import (
     EpisodeRequest,
     EpisodeRunner,
 )
+from .verification import VerifyInput, normalize_verify
 from .usecases.snapshot_artifacts import SnapshotArtifactWriter
 from .usecases.memory_sync import persist_episode_memory
 from .context import RuntimeContext, get_context
@@ -134,6 +135,8 @@ def solve(
     intuition: bool | Intuition = True,
     tags: Optional[Dict[str, Any]] = None,
     context: RuntimeContext | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
     determinism: "_DeterminismConfig | None" = None,
 ) -> str:
     app = context or get_context()
@@ -144,6 +147,8 @@ def solve(
         intuition=intuition,
         tags=tags,
         context=app,
+        workspace=workspace,
+        verify=verify,
         determinism=determinism,
     )
 
@@ -156,6 +161,8 @@ async def solve_async(
     intuition: bool | Intuition = True,
     tags: Optional[Dict[str, Any]] = None,
     context: RuntimeContext | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
     determinism: "_DeterminismConfig | None" = None,
 ) -> str:
     app = context or get_context()
@@ -166,6 +173,8 @@ async def solve_async(
         intuition=intuition,
         tags=tags,
         context=app,
+        workspace=workspace,
+        verify=verify,
         determinism=determinism,
     )
 
@@ -344,6 +353,8 @@ def _bootstrap_episode(
     raw_using_label: str,
     adapter_label: str,
     context: RuntimeContext,
+    workspace: str | Path | None,
+    verify: VerifyInput,
     intuition: bool | Intuition,
     determinism: "_DeterminismConfig | None",
 ) -> _EpisodeRuntime:
@@ -356,6 +367,8 @@ def _bootstrap_episode(
     run_clock, now_fn = _init_clock(determinism)
     ctx = _EpCtx(ids=ids, run_dir=run_dir, started_at=now_fn())
     intuition_impl, intuition_enabled = _normalize_intuition(cfg.intuition_mode, intuition)
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_specs = normalize_verify(verify)
 
     episode_ctx = EpisodeContext(
         run_dir=ctx.run_dir,
@@ -365,6 +378,8 @@ def _bootstrap_episode(
         tags=tags or {},
         adapter_label=adapter_label,
         started_at=ctx.started_at,
+        workspace=workspace_path,
+        verify=verify_specs,
         intuition_mode=cfg.intuition_mode,
         prompt_provenance_enabled=cfg.prompt_provenance_enabled,
         prompt_provenance_mode=cfg.prompt_provenance_mode,
@@ -516,6 +531,8 @@ def _run_impl(
     tags: Optional[Dict[str, Any]],
     using: Optional[GraphSource],
     context: RuntimeContext,
+    workspace: str | Path | None,
+    verify: VerifyInput,
     determinism: "_DeterminismConfig | None",
 ) -> str:
     minimal_mode = using is None
@@ -533,6 +550,8 @@ def _run_impl(
         raw_using_label=raw_using_label,
         adapter_label=adapter_label,
         context=context,
+        workspace=workspace,
+        verify=verify,
         intuition=intuition,
         determinism=determinism,
     )
@@ -643,9 +662,13 @@ def run(
     intuition: bool | Intuition = True,
     tags: Optional[Dict[str, Any]] = None,
     context: RuntimeContext | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
     determinism: "_DeterminismConfig | None" = None,
 ) -> str:
     app = context or get_context()
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_specs = normalize_verify(verify)
     return _run_impl(
         task=task,
         seed=seed,
@@ -653,6 +676,8 @@ def run(
         tags=tags,
         using=None,
         context=app,
+        workspace=workspace_path,
+        verify=verify_specs,
         determinism=determinism,
     )
 
@@ -665,9 +690,13 @@ def run_using(
     intuition: bool | Intuition = True,
     tags: Optional[Dict[str, Any]] = None,
     context: RuntimeContext | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
     determinism: "_DeterminismConfig | None" = None,
 ) -> str:
     app = context or get_context()
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_specs = normalize_verify(verify)
     return _run_impl(
         task=task,
         seed=seed,
@@ -675,6 +704,8 @@ def run_using(
         tags=tags,
         using=using,
         context=app,
+        workspace=workspace_path,
+        verify=verify_specs,
         determinism=determinism,
     )
 
@@ -687,9 +718,13 @@ async def run_using_async(
     intuition: bool | Intuition = True,
     tags: Optional[Dict[str, Any]] = None,
     context: RuntimeContext | None = None,
+    workspace: str | Path | None = None,
+    verify: VerifyInput = None,
     determinism: "_DeterminismConfig | None" = None,
 ) -> str:
     app = context or get_context()
+    workspace_path = Path(workspace) if workspace is not None else None
+    verify_specs = normalize_verify(verify)
     return await _run_impl_async(
         task=task,
         seed=seed,
@@ -697,6 +732,8 @@ async def run_using_async(
         tags=tags,
         using=using,
         context=app,
+        workspace=workspace_path,
+        verify=verify_specs,
         determinism=determinism,
     )
 
@@ -709,6 +746,8 @@ async def _run_impl_async(
     tags: Optional[Dict[str, Any]],
     using: Optional[GraphSource],
     context: RuntimeContext,
+    workspace: str | Path | None,
+    verify: VerifyInput,
     determinism: "_DeterminismConfig | None",
 ) -> str:
     minimal_mode = using is None
@@ -726,6 +765,8 @@ async def _run_impl_async(
         raw_using_label=raw_using_label,
         adapter_label=adapter_label,
         context=context,
+        workspace=workspace,
+        verify=verify,
         intuition=intuition,
         determinism=determinism,
     )

--- a/noesis/runtime/session/runner_port.py
+++ b/noesis/runtime/session/runner_port.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Protocol
+from pathlib import Path
+from typing import Mapping, Protocol, Sequence
 
 from noesis.context import RuntimeContext
 from noesis.intuition import Intuition
+from noesis.domain.verification import Assertion
 
 __all__ = ["RunnerProtocol", "SessionRunRequest"]
 
@@ -19,6 +21,8 @@ class SessionRunRequest:
     seed: int
     intuition: bool | Intuition | None
     tags: Mapping[str, object]
+    workspace: Path | None = None
+    verify: Sequence[Assertion] | None = None
 
 
 class RunnerProtocol(Protocol):

--- a/noesis/runtime/session/session.py
+++ b/noesis/runtime/session/session.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, MutableMapping, Optional
 
 from noesis.context import RuntimeContext
 from noesis.interfaces.config import ConfigPort, ConfigSnapshot
 from noesis.intuition import Intuition
+from noesis.verification import VerifyInput, normalize_verify
 
 from .models import SessionConfig, DeterminismConfig
 from .runner_port import RunnerProtocol, SessionRunRequest
@@ -60,10 +62,14 @@ class NoesisSession:
         seed: int = 0,
         intuition: bool | Intuition | None = True,
         tags: Optional[MutableMapping[str, Any]] = None,
+        workspace: str | Path | None = None,
+        verify: "VerifyInput" = None,
         runner: RunnerProtocol | None = None,
     ) -> str:
         """Execute a task either through the built-in core or a supplied runner."""
         merged_tags = self._config.merge_tags(tags)
+        workspace_path = Path(workspace) if workspace is not None else None
+        verify_specs = normalize_verify(verify)
         with self._lock.scoped():
             if runner is not None:
                 request = SessionRunRequest(
@@ -71,6 +77,8 @@ class NoesisSession:
                     seed=seed,
                     intuition=intuition,
                     tags=merged_tags,
+                    workspace=workspace_path,
+                    verify=verify_specs,
                 )
                 return runner.run(request, context=self._context)
 
@@ -82,6 +90,8 @@ class NoesisSession:
                 intuition=intuition,
                 tags=merged_tags,
                 context=self._context,
+                workspace=workspace_path,
+                verify=verify_specs,
                 determinism=self._config.determinism,
             )
 
@@ -93,11 +103,15 @@ class NoesisSession:
         seed: int = 0,
         intuition: bool | Intuition = True,
         tags: Optional[MutableMapping[str, Any]] = None,
+        workspace: str | Path | None = None,
+        verify: "VerifyInput" = None,
     ) -> str:
         """Execute a task using a supplied graph/adapter."""
         from noesis.core import run_using as core_run_using
 
         merged_tags = self._config.merge_tags(tags)
+        workspace_path = Path(workspace) if workspace is not None else None
+        verify_specs = normalize_verify(verify)
         with self._lock.scoped():
             return core_run_using(
                 using=using,
@@ -106,6 +120,8 @@ class NoesisSession:
                 intuition=intuition,
                 tags=merged_tags,
                 context=self._context,
+                workspace=workspace_path,
+                verify=verify_specs,
                 determinism=self._config.determinism,
             )
 
@@ -117,11 +133,15 @@ class NoesisSession:
         seed: int = 0,
         intuition: bool | Intuition = True,
         tags: Optional[MutableMapping[str, Any]] = None,
+        workspace: str | Path | None = None,
+        verify: "VerifyInput" = None,
     ) -> str:
         """Execute a task using a supplied graph/adapter (async)."""
         from noesis.core import run_using_async as core_run_using_async
 
         merged_tags = self._config.merge_tags(tags)
+        workspace_path = Path(workspace) if workspace is not None else None
+        verify_specs = normalize_verify(verify)
         with self._lock.scoped():
             return await core_run_using_async(
                 using=using,
@@ -130,6 +150,8 @@ class NoesisSession:
                 intuition=intuition,
                 tags=merged_tags,
                 context=self._context,
+                workspace=workspace_path,
+                verify=verify_specs,
                 determinism=self._config.determinism,
             )
 

--- a/noesis/verification.py
+++ b/noesis/verification.py
@@ -1,0 +1,82 @@
+"""Public verification helpers for workspace assertions."""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Iterable, Sequence, TypeAlias
+
+from noesis.domain.verification import (
+    Assertion,
+    FileContainsAssertion,
+    FileExistsAssertion,
+    NoModificationsAssertion,
+    OnlyModifiedAssertion,
+)
+
+VerifySpec: TypeAlias = Assertion
+VerifyInput: TypeAlias = VerifySpec | Sequence[VerifySpec] | None
+
+__all__ = [
+    "VerifyInput",
+    "VerifySpec",
+    "file_contains",
+    "file_exists",
+    "no_modifications",
+    "normalize_verify",
+    "only_modified",
+]
+
+
+def file_exists(path: str | Path) -> VerifySpec:
+    """Return a verification spec requiring a file to exist."""
+    return FileExistsAssertion(path)
+
+
+def file_contains(
+    path: str | Path,
+    pattern: str | re.Pattern[str],
+    *,
+    literal: bool = False,
+) -> VerifySpec:
+    """
+    Return a verification spec requiring file content to include a pattern.
+
+    Note: regex matching is not supported in v0.1; pass literal=True when using
+    a compiled pattern to match its raw string.
+    """
+    if isinstance(pattern, re.Pattern):
+        if not literal:
+            raise ValueError("regex patterns are not supported; pass literal=True")
+        text = pattern.pattern
+    else:
+        text = str(pattern)
+    return FileContainsAssertion(path, text)
+
+
+def only_modified(paths: Sequence[str | Path]) -> VerifySpec:
+    """Return a verification spec restricting modifications to the given paths."""
+    return OnlyModifiedAssertion(paths)
+
+
+def no_modifications() -> VerifySpec:
+    """Return a verification spec requiring no workspace modifications."""
+    return NoModificationsAssertion()
+
+
+def normalize_verify(verify: VerifyInput) -> tuple[VerifySpec, ...] | None:
+    """Normalize verification input into a tuple of verification specs."""
+    if verify is None:
+        return None
+    if _is_spec(verify):
+        return (verify,)
+    if isinstance(verify, Sequence) and not isinstance(verify, (str, bytes)):
+        specs = tuple(verify)
+        for spec in specs:
+            if not _is_spec(spec):
+                raise TypeError("verify must contain only verification specs")
+        return specs
+    raise TypeError("verify must be a verification spec or a sequence of specs")
+
+
+def _is_spec(value: object) -> bool:
+    return bool(getattr(value, "evaluate", None)) and bool(getattr(value, "name", None))

--- a/tests/public/test_verification_api.py
+++ b/tests/public/test_verification_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import noesis as ns
+
+
+def test_file_exists_helper_builds_spec() -> None:
+    spec = ns.file_exists("config.yaml")
+
+    assert spec.name == "file_exists"
+
+
+def test_file_contains_rejects_regex_without_literal() -> None:
+    pattern = re.compile(r"enabled:\s+true")
+
+    with pytest.raises(ValueError):
+        ns.file_contains("config.yaml", pattern)
+
+
+def test_file_contains_accepts_literal_regex() -> None:
+    pattern = re.compile(r"enabled:\s+true")
+
+    spec = ns.file_contains("config.yaml", pattern, literal=True)
+
+    assert spec.name == "file_contains"
+
+
+def test_normalize_verify_accepts_single_and_sequence() -> None:
+    single = ns.file_exists("config.yaml")
+    sequence = [ns.no_modifications()]
+
+    assert ns.normalize_verify(single) == (single,)
+    assert ns.normalize_verify(sequence) == tuple(sequence)
+
+
+def test_normalize_verify_rejects_invalid() -> None:
+    with pytest.raises(TypeError):
+        ns.normalize_verify(["bad"])


### PR DESCRIPTION
### Summary

This PR tightens the public API surface by normalizing `workspace` and `verify` as soon as they enter Noēsis. The normalized values are what flow through `noesis/__init__.py` → `noesis/core.py` → `noesis/runtime/session/session.py`, ensuring consistent typing and early, deterministic validation.

### Changes
- Normalize `workspace` to `Path | None` and `verify` via `normalize_verify` in:
  - `noesis/__init__.py` (`run`, `solve`, `solve_async`)
  - `noesis/runtime/session/session.py` (`run`, `solve`, `solve_async`)
  - `noesis/core.py` (`run`, `run_using`, `run_using_async`)
- Keep `normalize_verify` as a public, stable helper (already used in the public test suite).

### New API usage (PR4 public surface)

#### Basic verification
```python
import noesis as ns

episode_id = ns.solve(
    "Update config",
    using="my.module:adapter_fn",
    workspace=".",
    verify=[
        ns.file_exists("config.yaml"),
        ns.file_contains("config.yaml", "enabled: true"),
    ],
)
```

### Changes
- Normalize `workspace` to `Path | None` and `verify` via `normalize_verify` in:
  - `noesis/__init__.py` (`run`, `solve`, `solve_async`)
  - `noesis/runtime/session/session.py` (`run`, `solve`, `solve_async`)
  - `noesis/core.py` (`run`, `run_using`, `run_using_async`)
- Keep `normalize_verify` as a public, stable helper (already used in the public test suite).

### Behavior
No behavioral changes beyond earlier normalization / error surfacing.

### Verification
- Existing test suite passes (including replay gate + golden diagnostics).
- Recommend running:
  - `pytest -q`