### PR TITLE
eat(layout): default artifact root to .noesis/episodes; align docs + TUI autodetection with ADR-013

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
     M --> O
 ```
 
-- Artifacts (under `runs/<label>/<episode_id>/`):
+- Artifacts (under `.noesis/episodes/<episode_id>/` by default; set `runs_dir` to add a label):
   - `events.jsonl` – timeline with causal IDs
   - `summary.json` – metrics, outcome, cross-links
   - `state.json` – current plan and episode state
@@ -71,7 +71,7 @@ uv tool install .
 brew install jq
 ```
 
-Minimal run (emits artifacts to `./runs` by default):
+Minimal run (emits artifacts to `./.noesis/episodes` by default):
 
 ```python
 import noesis as ns
@@ -87,8 +87,8 @@ print(timeline[0]["phase"], timeline[0].get("payload"))
 Artifacts layout:
 
 ```
-runs/
-  demo/              # label (configurable)
+.noesis/
+  episodes/
     ep_.../          # episode id
       summary.json
       state.json
@@ -119,7 +119,7 @@ Toggle governance depth:
 ```python
 import noesis as ns
 
-ns.set(runs_dir="./runs/demo")
+ns.set(runs_dir="./.noesis/episodes/demo")
 ns.set(planner_mode="meta")      # with governance (default)
 ns.run("Summarize release notes", intuition=False)
 
@@ -151,7 +151,7 @@ Config snapshots (read/write current session config):
 ```python
 import noesis as ns
 
-ns.set(runs_dir="./runs/demo", planner_mode="minimal", governance_mode="audit")
+ns.set(runs_dir="./.noesis/episodes/demo", planner_mode="minimal", governance_mode="audit")
 config = ns.get()
 print(config["runs_dir"], config["planner_mode"])
 ```
@@ -189,7 +189,7 @@ except NoesisVeto as veto:
 
 ## Docs & links
 - Artifacts guide: `docs/artifacts/state.md`
-- Runs cheat sheet: `runs/README.md`
+- Runs cheat sheet: `docs/explanation/artifacts.mdx`
 - Schema index: `docs/app/reference/schema-index.mdx`
 - CLI reference: `docs/app/reference/cli/page.mdx`
 - Quickstart guide: `docs/app/guides/quickstart/page.mdx`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ Noēsis is a cognitive framework. To protect its identity and prevent scope drif
 - ✅ Schema-governed prompt records (`$schema_name: prompt`, `$schema_version: 1.1.0`) with fixtures and schema guard (`internal_docs/schema/prompt.v1.yaml`, `docs/schema/prompt/1.1.0.json`, `tests/runtime/test_prompt_schema.py`).
 - ✅ PromptRecorder with `full` / `hash_only` / `redacted` modes, deterministic hashing, manifest integration, and leakage guards (`noesis/runtime/prompt_recorder.py`, `tests/runtime/test_prompt_recorder.py`).
 - ✅ Recorded prompts across interpret, plan, governance, and reflect phases with tag threading and event linkage where available (`noesis/usecases/episode_runner.py`).
-- ✅ Docs updated to mark prompts.jsonl experimental with mode semantics and schema reference (`docs/runs/README.md`).
+- ✅ Docs updated to mark prompts.jsonl experimental with mode semantics and schema reference (`docs/explanation/artifacts.mdx`).
 
 ### Accepted Baseline Metrics
 

--- a/docs/explanation/artifacts.mdx
+++ b/docs/explanation/artifacts.mdx
@@ -8,7 +8,7 @@ Every Noēsis episode produces a set of structured artifacts that capture the co
 ## Artifact structure
 
 ```
-runs/
+.noesis/episodes/
   <label>/                     # e.g., "demo", "production"
     <episode_id>/              # e.g., "ep_20251108_120000_abc123_def4_s0"
       events.jsonl             # cognitive event timeline with lineage
@@ -409,7 +409,7 @@ Learning signals are stored separately when the learn phase emits proposals.
 import json
 from pathlib import Path
 
-learn_path = Path(f"runs/demo/{episode_id}/learn.jsonl")
+learn_path = Path(f".noesis/episodes/{episode_id}/learn.jsonl")
 
 if learn_path.exists():
     with open(learn_path) as f:
@@ -471,10 +471,10 @@ Organize episodes with labels:
 import noesis as ns
 
 ns.set(label="production")
-# Artifacts go to runs/production/ep_.../
+# Artifacts go to .noesis/episodes/production/ep_.../
 
 ns.set(label="staging")
-# Artifacts go to runs/staging/ep_.../
+# Artifacts go to .noesis/episodes/staging/ep_.../
 ```
 
 ### Retention
@@ -484,7 +484,7 @@ Control artifact retention:
 ```python
 from noesis.episode import EpisodeIndex
 
-store = EpisodeIndex("./runs/_episodes", ttl_days=14)
+store = EpisodeIndex("./.noesis/episodes/_episodes", ttl_days=14)
 store.vacuum()  # Remove episodes older than 14 days
 ```
 

--- a/docs/explanation/core-concepts.mdx
+++ b/docs/explanation/core-concepts.mdx
@@ -145,7 +145,7 @@ class MyPolicy(ns.DirectedIntuition):
 Every episode produces structured **artifacts** that capture the full cognitive trace:
 
 ```
-runs/
+.noesis/episodes/
   demo/                    # label
     ep_2024_abc123_s0/     # episode
       summary.json         # metrics and outcomes

--- a/docs/explanation/prompt-provenance.mdx
+++ b/docs/explanation/prompt-provenance.mdx
@@ -10,7 +10,7 @@ Prompt provenance captures how prompts were constructed and used during an episo
 | Property | Value |
 | --- | --- |
 | File | `prompts.jsonl` |
-| Location | `runs/<label>/<episode_id>/prompts.jsonl` |
+| Location | `.noesis/episodes/<label>/<episode_id>/prompts.jsonl` |
 | Schema | `$schema_name: "prompt"`, `$schema_version: "1.1.0"` |
 | Kind | `attachment` in `manifest.json` |
 | Opt-in | `prompt_provenance_enabled` (bool) |

--- a/docs/guides/adopting-noesis.mdx
+++ b/docs/guides/adopting-noesis.mdx
@@ -3,7 +3,7 @@ title: "Adopting Noēsis in real systems"
 description: "Move from local traces to team-wide observability and evals without surprises."
 ---
 
-Noēsis is easy to try locally: install the package, run an episode, open `runs/demo/...`, and you can literally **see your agent think**. This guide is for the moment _after_ that first “wow”:
+Noēsis is easy to try locally: install the package, run an episode, open `.noesis/episodes/<episode-id>/`, and you can literally **see your agent think**. This guide is for the moment _after_ that first “wow”:
 
 > “I like this. How do I use it responsibly in a real service, team, or eval harness?”
 
@@ -33,7 +33,7 @@ Most teams start by wrapping a single agent or eval harness and grow from there.
 
 Only then ask: “Where should these episodes live if multiple people or services produce them?”
 
-- Local only: keep default `./runs/demo/...`.
+- Local only: keep default `./.noesis/episodes/<episode-id>/`.
 - Shared dev: network volume/S3/mounted path in Docker/Kubernetes.
 - Service-level: scoped location per app/team.
 
@@ -42,7 +42,7 @@ You don’t need a perfect “episode store” on day one—pick **one** place t
 ## 3) Where to store episodes
 
 ```
-./runs/demo/<episode-id>/
+./.noesis/episodes/<episode-id>/
   events.jsonl
   summary.json
   state.json
@@ -54,11 +54,11 @@ Goal: make episodes easy to find, safe to keep, and cheap to delete.
 </Note>
 
 **Local dev / CI**
-- Keep `./runs/...`.
+- Keep `./.noesis/episodes/...`.
 - Add cleanup: in CI delete after each job; on dev machines prune old runs (`find runs -mtime +7 -delete` or similar).
 
 **Shared / long-lived (later, if Noēsis becomes central)**
-- Centralize base path: `/var/noesis/runs/<service>/<date>/...` or a mounted volume/S3 prefix.
+- Centralize base path: `/var/noesis/episodes/<service>/<date>/...` or a mounted volume/S3 prefix.
 - Add retention: keep N latest per service, and “golden” episodes (evals, interesting failures) tagged for longer.
 - Noēsis never deletes by itself—use your scheduler/scripts.
 

--- a/docs/guides/configure-planner-modes.mdx
+++ b/docs/guides/configure-planner-modes.mdx
@@ -45,7 +45,7 @@ Create a `noesis.toml` in your project root:
 ```toml noesis.toml
 [noesis]
 planner_mode = "meta"
-runs_dir = "./runs"
+runs_dir = "./.noesis/episodes"
 ```
 
 ### Precedence

--- a/docs/guides/configure-shared-storage.mdx
+++ b/docs/guides/configure-shared-storage.mdx
@@ -3,7 +3,7 @@ title: "Configure shared episode storage"
 description: "Point Noēsis at a shared location via network volumes, S3 sync, Docker mounts, or Kubernetes PVCs."
 ---
 
-By default, Noēsis writes episodes under `./runs/demo/...`. In a team or service setting, you usually want a **shared** location so everyone can see/replay the same traces.
+By default, Noēsis writes episodes under `./.noesis/episodes/<episode-id>/`. In a team or service setting, you usually want a **shared** location so everyone can see/replay the same traces.
 
 This guide shows four common setups:
 
@@ -19,8 +19,8 @@ Pick one of these patterns for your environment—you don’t need all four.
 ## A) Shared dev: network volume
 
 ```bash
-# Example: shared volume mounted at /srv/noesis/runs
-ls /srv/noesis/runs
+# Example: shared volume mounted at /srv/noesis/episodes
+ls /srv/noesis/episodes
 # (empty or existing runs)
 ```
 
@@ -28,10 +28,10 @@ Configure your app/runtime to use it as the base runs directory, e.g.:
 
 ```bash
 # pseudo-config
-NOESIS_RUNS_DIR=/srv/noesis/runs
+NOESIS_RUNS_DIR=/srv/noesis/episodes
 ```
 
-Result: `/srv/noesis/runs/<service>/<episode-id>/` is shared across the team.
+Result: `/srv/noesis/episodes/<service>/<episode-id>/` is shared across the team.
 
 ## B) Shared dev: local + S3 (or any object store)
 
@@ -39,13 +39,13 @@ Don’t write directly to S3; sync a local directory.
 
 ```bash
 # App writes episodes locally
-NOESIS_RUNS_DIR=/var/noesis/runs
+NOESIS_RUNS_DIR=/var/noesis/episodes
 
 # Periodic sync job (cron/CI)
-aws s3 sync /var/noesis/runs s3://my-bucket/noesis-runs --delete
+aws s3 sync /var/noesis/episodes s3://my-bucket/noesis-runs --delete
 
 # Optionally pull shared episodes down
-aws s3 sync s3://my-bucket/noesis-runs /var/noesis/runs
+aws s3 sync s3://my-bucket/noesis-runs /var/noesis/episodes
 ```
 
 Pattern: local path for fast replay/debugging, S3 as central archive.
@@ -53,15 +53,15 @@ Pattern: local path for fast replay/debugging, S3 as central archive.
 ## C) Docker: bind-mount the runs directory
 
 ```bash
-mkdir -p /srv/noesis/runs
+mkdir -p /srv/noesis/episodes
 
 docker run \
-  -v /srv/noesis/runs:/app/runs \
-  -e NOESIS_RUNS_DIR=/app/runs \
+  -v /srv/noesis/episodes:/app/.noesis/episodes \
+  -e NOESIS_RUNS_DIR=/app/.noesis/episodes \
   my-noesis-service:latest
 ```
 
-Inside the container, Noēsis writes to `/app/runs/...`; on the host, you see `/srv/noesis/runs/...`.
+Inside the container, Noēsis writes to `/app/.noesis/episodes/...`; on the host, you see `/srv/noesis/episodes/...`.
 
 ## D) Kubernetes: PersistentVolumeClaim
 
@@ -88,17 +88,17 @@ spec:
           image: my-noesis-service:latest
           env:
             - name: NOESIS_RUNS_DIR
-              value: /var/noesis/runs
+              value: /var/noesis/episodes
           volumeMounts:
             - name: noesis-runs
-              mountPath: /var/noesis/runs
+              mountPath: /var/noesis/episodes
       volumes:
         - name: noesis-runs
           persistentVolumeClaim:
             claimName: noesis-runs-pvc
 ```
 
-Each pod writes episodes under `/var/noesis/runs`, backed by the shared PVC.
+Each pod writes episodes under `/var/noesis/episodes`, backed by the shared PVC.
 
 ---
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -88,7 +88,7 @@ print(timeline[0]["phase"], timeline[0].get("payload"))
 Every run produces a clean artifact structure:
 
 ```
-runs/
+.noesis/episodes/
   demo/                # label (configurable)
     ep_.../            # episode id
       summary.json     # metrics and outcomes

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -49,7 +49,7 @@ The PyPI release is pending. For now, install from source:
     noesis run "hello world" 
     ```
 
-    This prints and stores the episode ID (for example, `ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C`) and creates artifacts in the `runs/` directory, relative to where you run the command.
+    This prints and stores the episode ID (for example, `ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C`) and creates artifacts in the `.noesis/episodes/` directory, relative to where you run the command.
   </Step>
 
   <Step title="List recent episodes">
@@ -94,10 +94,10 @@ for event in events:
 
 ## Inspect artifacts
 
-Every episode creates a structured artifact directory (written under `runs/` by default, relative to where you run the command):
+Every episode creates a structured artifact directory (written under `.noesis/episodes/` by default, relative to where you run the command):
 
 ```
-runs/
+.noesis/episodes/
   ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/   # episode id (ULID)
     summary.json                  # metrics + rollups
     state.json                    # final state snapshot
@@ -111,7 +111,7 @@ runs/
 The `_episodes/` index is written on a best-effort basis at the end of runs and may be missing or empty (for example, if indexing fails due to permissions).
 
 <Tip>
-Use `jq` for pretty-printing JSON artifacts: `cat runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json | jq .`
+Use `jq` for pretty-printing JSON artifacts: `cat .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json | jq .`
 
 To change the artifact location, set `NOESIS_RUNS_DIR` or in Python call `ns.set(runs_dir="./my-runs")`.
 </Tip>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -345,9 +345,9 @@ noesis view ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C --open
 
 ```
 === artifacts ===
-dir: runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C
-summary: runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json
-events: runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/events.jsonl
+dir: .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C
+summary: .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json
+events: .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/events.jsonl
 
 === timeline ===
 [start] 2024-12-27T10:15:32.000Z
@@ -507,7 +507,7 @@ noesis artifacts verify ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C --strict
 
 ```
 Artifact verification
-manifest : runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/manifest.json
+manifest : .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/manifest.json
 status   : ok
 files    : 4
 duration : 12.34 ms
@@ -523,7 +523,7 @@ files detail:
 
 ```
 === Artifact verification ===
-manifest : runs/ep_2024_abc123_s0/manifest.json
+manifest : .noesis/episodes/ep_2024_abc123_s0/manifest.json
 status   : ok
 files    : 4
 duration : 12.34 ms
@@ -588,7 +588,7 @@ noesis diagnostics --strict
 noesis diagnostics --checks runs_dir,ports,artifact_manifest
 
 # Drift compare two runs
-noesis diagnostics replay runs/ep_a runs/ep_b
+noesis diagnostics replay .noesis/episodes/ep_a .noesis/episodes/ep_b
 ```
 
 Replay exits `1` on drift, `0` otherwise. Default mode exits `1` on errors (or warnings when `--strict`).
@@ -603,15 +603,15 @@ summary_schema_version: 1.1.0
 state_version         : 1 (schema 1.0)
 selected_checks       : all
 checks:
-  [ok] runs_dir - ./runs
+  [ok] runs_dir - ./.noesis/episodes
   [ok] learn_home - ~/.noesis/state
   [ok] direction_min_confidence - 0.50
   [ok] learn_auto_apply_min_confidence - 0.75
   [ok] learn_auto_apply_min_successes - 3
   [ok] ports - config=config/1.0-rc1
   [ok] config_snapshot - in sync
-  [ok] latest_summary - runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json
-  [ok] artifact_manifest - runs/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/manifest.json
+  [ok] latest_summary - .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/summary.json
+  [ok] artifact_manifest - .noesis/episodes/ep_01JH6Z2V9Q2K6Y6N0QZ7K2QW8C/manifest.json
 overall status        : ok
 ```
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -25,7 +25,7 @@ Directory where artifacts are stored.
 | Python | `ns.set(runs_dir="./my-runs")` |
 | Environment | `NOESIS_RUNS_DIR=./my-runs` |
 | TOML | `runs_dir = "./my-runs"` |
-| Default | `"runs"` |
+| Default | `".noesis/episodes"` |
 
 ### planner_mode
 
@@ -264,7 +264,7 @@ The recommended form is a `[noesis]` table (if the table is missing, Noēsis fal
 
 ```toml noesis.toml
 [noesis]
-runs_dir = "./runs"
+runs_dir = "./.noesis/episodes"
 agents = "agents.yaml"
 tasks = "tasks.yaml"
 planner_mode = "meta"
@@ -363,7 +363,7 @@ import noesis as ns
 
 # Set back to defaults explicitly
 ns.set(
-    runs_dir="./runs",
+    runs_dir="./.noesis/episodes",
     planner_mode="meta",
     direction_min_confidence=0.5,
     governance_mode="off",
@@ -442,7 +442,7 @@ except ValueError as e:
 
 ```toml noesis.toml
 [noesis]
-runs_dir = "./runs"
+runs_dir = "./.noesis/episodes"
 planner_mode = "minimal"
 direction_min_confidence = 0.5
 governance_mode = "off"
@@ -453,7 +453,7 @@ prompt_provenance_enabled = false
 
 ```toml noesis.toml
 [noesis]
-runs_dir = "./runs"
+runs_dir = "./.noesis/episodes"
 planner_mode = "meta"
 learn_mode = "record"
 direction_min_confidence = 0.5
@@ -465,7 +465,7 @@ prompt_provenance_enabled = false
 
 ```toml noesis.toml
 [noesis]
-runs_dir = "/var/noesis/runs"
+runs_dir = "/var/noesis/episodes"
 planner_mode = "meta"
 learn_mode = "record"
 governance_mode = "enforce"

--- a/docs/reference/python-api.mdx
+++ b/docs/reference/python-api.mdx
@@ -202,7 +202,7 @@ episode_id = last(*, context: Any | None = None) -> str | None
 Update or read the current configuration snapshot.
 
 ```python
-ns.set(runs_dir="runs", planner_mode="minimal", direction_min_confidence=0.7)
+ns.set(runs_dir=".noesis/episodes", planner_mode="minimal", direction_min_confidence=0.7)
 config = ns.get()  # returns a mapping of current config values
 ```
 
@@ -420,7 +420,7 @@ Manage an on-disk episode manifest (and optional FAISS similarity index).
 from noesis.episode import EpisodeIndex
 
 store = EpisodeIndex(
-    root="./runs/_episodes",
+    root="./.noesis/episodes/_episodes",
     ttl_days=14,
     enable_faiss=False,  # set True if faiss + numpy installed and you provide embeddings
 )

--- a/docs/reference/state.mdx
+++ b/docs/reference/state.mdx
@@ -408,7 +408,7 @@ print(f"Steps: {len(state['plan']['steps'])}")
 ### File access
 
 ```bash
-cat runs/demo/ep_abc123/state.json | jq '.outcomes.status'
+cat .noesis/episodes/ep_abc123/state.json | jq '.outcomes.status'
 ```
 
 ## Policy usage

--- a/docs/reference/summary.mdx
+++ b/docs/reference/summary.mdx
@@ -374,7 +374,7 @@ noesis show ep_abc123 -j | jq '.metrics.success'
 ### File access
 
 ```bash
-cat runs/demo/ep_abc123/summary.json | jq .
+cat .noesis/episodes/ep_abc123/summary.json | jq .
 ```
 
 ## Use cases

--- a/docs/tutorials/first-episode.mdx
+++ b/docs/tutorials/first-episode.mdx
@@ -56,7 +56,7 @@ noesis list -j | jq '.[0]'
 Navigate to the runs directory to see what was created:
 
 ```bash
-ls runs/demo/ep_2024_abc123_s0/
+ls .noesis/episodes/ep_2024_abc123_s0/
 ```
 
 You'll find:
@@ -71,7 +71,7 @@ You'll find:
 ### Reading the summary
 
 ```bash
-cat runs/demo/ep_2024_abc123_s0/summary.json | jq .
+cat .noesis/episodes/ep_2024_abc123_s0/summary.json | jq .
 ```
 
 ```json
@@ -98,7 +98,7 @@ cat runs/demo/ep_2024_abc123_s0/summary.json | jq .
 ### Reading the event timeline
 
 ```bash
-cat runs/demo/ep_2024_abc123_s0/events.jsonl | jq -s .
+cat .noesis/episodes/ep_2024_abc123_s0/events.jsonl | jq -s .
 ```
 
 Each event includes:

--- a/docs/tutorials/guarded-langgraph-agent.mdx
+++ b/docs/tutorials/guarded-langgraph-agent.mdx
@@ -212,7 +212,7 @@ def run_case(task: str, label: str, intuition: Any, using: Any) -> str | None:
         return None
 
 
-def show_episode_results(episode_id: str, runs_dir: str = "runs") -> None:
+def show_episode_results(episode_id: str, runs_dir: str = ".noesis/episodes") -> None:
     print_guarded_episode_results(episode_id, runs_dir=runs_dir)
 ```
 

--- a/docs/tutorials/hello-episode.mdx
+++ b/docs/tutorials/hello-episode.mdx
@@ -16,7 +16,7 @@ Learning path:
 ## What you'll build
 
 - A one-call agent that returns an LLM answer
-- A recorded episode under `runs/demo/<episode-id>/`
+- A recorded episode under `.noesis/episodes/<episode-id>/`
 - A timeline with phases and a couple of quick metrics
 
 ## Prerequisites
@@ -56,10 +56,10 @@ Auth reminder: Noēsis does not create API keys for you. Set `OPENAI_API_KEY` (o
 
 ## 2) Open the episode folder
 
-Episodes are written to `runs/demo/<episode-id>/`. Inspect the files:
+Episodes are written to `.noesis/episodes/<episode-id>/`. Inspect the files:
 
 ```bash
-ls runs/demo/<episode-id>/
+ls .noesis/episodes/<episode-id>/
 ```
 
 | File | What it tells you |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,10 @@
 # Examples & Learning Path
 
-Use these scenarios to introduce Noēsis concepts to engineers, operators, and stakeholders. Each folder keeps real code alongside the immutable artifacts stored in `runs/`.
+Use these scenarios to introduce Noēsis concepts to engineers, operators, and stakeholders. Each folder keeps real code alongside the immutable artifacts stored in `.noesis/episodes/`.
 
 ## Quickstart
 
-- `examples/demo.py` – one-file tour that runs two tasks (normal + vetoed) and prints summaries. Pair it with [`runs/README.md`](../runs/README.md) to explain the emitted artifacts.
+- `examples/demo.py` – one-file tour that runs two tasks (normal + vetoed) and prints summaries. Pair it with [`docs/explanation/artifacts.mdx`](../docs/explanation/artifacts.mdx) to explain the emitted artifacts.
 - `examples/artifacts/state_v1_example.json` – trimmed state snapshot used throughout the README and docs.
 
 ## Governance & operations
@@ -25,6 +25,6 @@ Use these scenarios to introduce Noēsis concepts to engineers, operators, and s
 ### Suggested flow for new contributors
 
 1. Run `uv run python examples/demo.py`.
-2. Open the emitted `runs/demo/<episode>/summary.json` and `state.json`.
+2. Open the emitted `.noesis/episodes/demo/<episode>/summary.json` and `state.json`.
 3. Step up to `uv run python -m examples.incident_triage.gradio_app` to see governance + dashboards.
 4. Customize `context.register("memory", ...)` to plug in domain memories or insight evaluators.

--- a/examples/artifacts/state_v1_example.json
+++ b/examples/artifacts/state_v1_example.json
@@ -90,7 +90,7 @@
         "result_artifacts": [
           {
             "type": "log",
-            "uri": "runs/ep_20250101_120000_123456_abcd_s0/rollback.log"
+            "uri": ".noesis/episodes/ep_20250101_120000_123456_abcd_s0/rollback.log"
           }
         ]
       }
@@ -101,7 +101,7 @@
     "artifacts": [
       {
         "type": "report",
-        "uri": "runs/ep_20250101_120000_123456_abcd_s0/report.md"
+        "uri": ".noesis/episodes/ep_20250101_120000_123456_abcd_s0/report.md"
       }
     ]
   },

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -3,7 +3,7 @@ import noesis as ns
 from noesis import context
 
 # keep demo runs separate
-ns.set(runs_dir="./runs/demo")
+ns.set(runs_dir="./.noesis/episodes/demo")
 
 # (optional) pin planner mode; default is meta
 # ns.set(planner_mode="meta")  # or "minimal" to compare

--- a/examples/noesis-quickstart/README.md
+++ b/examples/noesis-quickstart/README.md
@@ -25,10 +25,10 @@ After a run completes, you’ll get an `episode_id`. View it with:
 ```bash
 noesis view <episode_id>
 # or (works from anywhere):
-noesis view runs/<episode_id>
+noesis view .noesis/episodes/<episode_id>
 ```
 
-If you see “no events matched,” point the viewer to the `runs` folder that holds the episode.
+If you see “no events matched,” point the viewer to the `.noesis/episodes` folder that holds the episode.
 
 ## Tutorials
 
@@ -39,12 +39,12 @@ If you see “no events matched,” point the viewer to the `runs` folder that h
 uv run python -m tutorials.hello_episode
 ```
 - What you’ll learn:
-  - Where artifacts live: `runs/<episode_id>/...`
+  - Where artifacts live: `.noesis/episodes/<episode_id>/...`
   - Which phases happened: observe → interpret → plan → governance → act → reflect → learn → terminate → (insight/memory)
   - How to inspect runs: `noesis view <episode_id>`
 - Expected artifacts:
 ```
-runs/<episode_id>/
+.noesis/episodes/<episode_id>/
   events.jsonl
   state.json
   summary.json
@@ -73,4 +73,4 @@ uv run python -m tutorials.guarded_langgraph
 ```bash
 uv run python -m tutorials.trace_based_evals
 ```
-- Expectation: produce an episode whose summary includes evaluation metrics; review them in `noesis view` and in the written artifacts under `runs/<episode_id>/`.
+- Expectation: produce an episode whose summary includes evaluation metrics; review them in `noesis view` and in the written artifacts under `.noesis/episodes/<episode_id>/`.

--- a/examples/noesis-quickstart/common/paths.py
+++ b/examples/noesis-quickstart/common/paths.py
@@ -16,11 +16,11 @@ class QuickstartPaths:
 def get_paths() -> QuickstartPaths:
     """
     Canonical layout for this repo.
-    - runs/: where episodes + reports go
+    - .noesis/episodes/: where episodes + reports go
     - .sandbox/: safe filesystem demo area
     """
     root = Path(__file__).resolve().parent.parent
-    runs = root / "runs"
+    runs = root / ".noesis" / "episodes"
     sandbox = root / ".sandbox"
 
     runs.mkdir(parents=True, exist_ok=True)

--- a/examples/noesis-quickstart/common/reporting.py
+++ b/examples/noesis-quickstart/common/reporting.py
@@ -121,7 +121,7 @@ def print_case(label: str, task: str, episode_id: str | None) -> None:
         warn("Episode ID: unavailable")
 
 
-def print_guarded_episode_results(episode_id: str, runs_dir: str = "runs") -> None:
+def print_guarded_episode_results(episode_id: str, runs_dir: str = ".noesis/episodes") -> None:
     try:
         events = read_events_jsonl(runs_dir=runs_dir, episode_id=episode_id, limit=80)
         summary = read_summary_json(runs_dir=runs_dir, episode_id=episode_id)

--- a/examples/noesis-quickstart/tutorials/guarded_langgraph.py
+++ b/examples/noesis-quickstart/tutorials/guarded_langgraph.py
@@ -182,7 +182,7 @@ def run_case(task: str, label: str, intuition: Any, using: Any) -> str | None:
         return None
 
 
-def show_episode_results(episode_id: str, runs_dir: str = "runs") -> None:
+def show_episode_results(episode_id: str, runs_dir: str = ".noesis/episodes") -> None:
     print_guarded_episode_results(episode_id, runs_dir=runs_dir)
 
 

--- a/examples/noesis-quickstart/tutorials/hello_episode.py
+++ b/examples/noesis-quickstart/tutorials/hello_episode.py
@@ -101,11 +101,9 @@ def main() -> int:
         episode_id = ns.run(task, intuition=True)
         success(f"Episode ID: {episode_id}")
 
-        # Your repo’s README says runs are under ./runs by default.
-        # If you want a fixed label, set it explicitly:
-        # ns.set(runs_dir="./runs/demo")
-
-        runs_dir = "runs"  # repo-root relative
+        # Use the configured runs_dir to locate artifacts.
+        config = ns.get()
+        runs_dir = str(config.get("runs_dir", ".noesis/episodes"))
         ep_dir = episode_dir(runs_dir, episode_id)
         success(f"Episode folder: {ep_dir}")
 

--- a/internals/schema/state.v1.yaml
+++ b/internals/schema/state.v1.yaml
@@ -40,7 +40,7 @@ json_schema:
           stability: stable
         label:
           type: string
-          description: Human-friendly folder label (e.g., runs/demo).
+          description: Human-friendly folder label (e.g., .noesis/episodes/demo).
           stability: beta
         using:
           type: string

--- a/noesis-tui/internal/cli/client.go
+++ b/noesis-tui/internal/cli/client.go
@@ -37,7 +37,7 @@ func NewClient() *Client {
 	}
 }
 
-// detectRunsDir looks for a runs/ directory containing episodes in parent directories.
+// detectRunsDir looks for a .noesis/episodes directory containing episodes in parent directories.
 func detectRunsDir() string {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -46,7 +46,7 @@ func detectRunsDir() string {
 
 	dir := cwd
 	for {
-		runsPath := filepath.Join(dir, "runs")
+		runsPath := filepath.Join(dir, ".noesis", "episodes")
 		if isNoesisRunsDir(runsPath) {
 			return runsPath
 		}

--- a/noesis/domain/config/settings.py
+++ b/noesis/domain/config/settings.py
@@ -59,7 +59,7 @@ class RuntimeConfig:
 def default_runtime_config() -> RuntimeConfig:
     """Return the immutable default configuration."""
     return RuntimeConfig(
-        runs_dir=Path("runs"),
+        runs_dir=Path(".noesis") / "episodes",
         agents="agents.yaml",
         tasks="tasks.yaml",
         timeout_sec=60,

--- a/noesis/runtime/paths.py
+++ b/noesis/runtime/paths.py
@@ -56,6 +56,8 @@ def resolve_noesis_paths(*, workspace: Path | None, runs_dir: Path) -> NoesisPat
 def resolve_noesis_root(*, workspace: Path, runs_dir: Path) -> Path:
     workspace = workspace.expanduser().resolve()
     runs_dir = runs_dir.expanduser().resolve()
+    if runs_dir.name == "episodes" and runs_dir.parent.name == ".noesis":
+        return runs_dir.parent
     if runs_dir.name == ".noesis":
         return runs_dir
     candidate = runs_dir / ".noesis"

--- a/noesis/usecases/snapshot_workspace.py
+++ b/noesis/usecases/snapshot_workspace.py
@@ -15,7 +15,7 @@ class SnapshotWorkspace:
 
     Integration note:
     EpisodeRunner/solve will invoke this use case before and after Act to
-    persist pre/post snapshots into runs/<episode_id>/snapshots in a later PR.
+    persist pre/post snapshots into .noesis/episodes/<episode_id>/snapshots in a later PR.
     """
 
     gateway: SnapshotGateway

--- a/tests/runtime/test_artifact_invariants.py
+++ b/tests/runtime/test_artifact_invariants.py
@@ -10,6 +10,7 @@ import pytest
 from jsonschema import validate
 
 import noesis as ns
+from noesis.config import EnvTomlConfig
 from noesis.cli.viewer import load_episode_view
 from noesis.cli.view_models import build_episode_dashboard
 from noesis.runtime.artifacts.manifest import compute_sha256
@@ -34,6 +35,8 @@ def _tutorial_context(tmp_path: Path) -> Path:
     runs_dir.mkdir(parents=True, exist_ok=True)
     learn_dir.mkdir(parents=True, exist_ok=True)
 
+    session_provider = ns.session_provider()
+    session: ns.NoesisSession | None = None
     original_cwd = Path.cwd()
     original_env = dict(os.environ)
     sys.path.insert(0, str(tutorial_root))
@@ -41,8 +44,12 @@ def _tutorial_context(tmp_path: Path) -> Path:
     os.environ["NOESIS_LEARN_HOME"] = str(learn_dir)
     os.chdir(tmp_path)
     try:
+        config_port = EnvTomlConfig(env=os.environ, cwd=tmp_path)
+        builder = ns.SessionBuilder(config_port=config_port)
+        session = ns.create_session(builder)
         layout = resolve_noesis_paths(workspace=None, runs_dir=runs_dir)
-        yield layout.episodes_dir
+        with session_provider.use(session):
+            yield layout.episodes_dir
     finally:
         os.chdir(original_cwd)
         os.environ.clear()


### PR DESCRIPTION
## Summary

This PR updates the default artifact root to the ADR-013 canonical layout by making new runs write under **`.noesis/episodes`** (a hidden dotfolder on macOS). It also updates `noesis-tui` auto-detection and aligns docs/examples and internal references to consistently point at `.noesis/episodes`.

## Changes

### Runtime default artifact root
- Updated the default runs/artifact directory to **`.noesis/episodes`** so the runtime creates the expected `.noesis` tree on first run.

**File**
- `noesis/domain/config/settings.py`

### TUI autodetection
- Updated TUI path detection to look for **`.noesis/episodes`** in canonical layout.

**File**
- `noesis-tui/internal/cli/client.go`

### Docs, examples, and internal references
- Updated documentation and examples to reference **`.noesis/episodes`** and removed implied `demo/` labeling where it wasn’t actually set.
- Updated schema/internal references and snapshot workspace logic to match the new default path.

**Files (high-level)**
- `README.md`
- `docs/quickstart.mdx`
- `docs/tutorials/hello-episode.mdx`
- `docs/tutorials/first-episode.mdx`
- `docs/guides/configure-shared-storage.mdx`
- `examples/noesis-quickstart/...`
- `internals/schema/state.v1.yaml`
- `noesis/usecases/snapshot_workspace.py`

## Behavior / Migration Notes
- New runs will create `.noesis/episodes/<episode-id>/` by default (use `ls -a` to see `.noesis` on macOS).
- If you have existing `runs/` artifacts you want to retain, either:
  - move them under `.noesis/episodes`, or
  - set `NOESIS_RUNS_DIR` to the prior location.

## Verification
Recommended manual check:
```bash
# run a quick episode, then:
ls -a .noesis/episodes
