### PR TITLE
feat(artifacts): enforce episode immutability guard with safe paths and cycle-free imports

### DIFF
--- a/noesis/core.py
+++ b/noesis/core.py
@@ -57,6 +57,7 @@ from .trace.schema import SUMMARY_SCHEMA_VERSION
 from .runtime.artifacts.ids import EpisodeIds
 from .runtime.artifacts.writer import ManifestWriter
 from .runtime.artifacts.manifest import MANIFEST_SCHEMA_VERSION, MANIFEST_FILE_NAME, compute_sha256
+from .runtime.artifacts.immutability import default_artifact_guard
 from .runtime.paths import NoesisPaths
 from .usecases.episode_runner import (
     EpisodeDependencies,
@@ -516,6 +517,7 @@ def _run_episode(
         gateway=FileSystemSnapshotGateway(),
         metadata_store=FileSystemSnapshotMetadataStore(),
         clock=UtcSnapshotClock(),
+        immutability_guard=default_artifact_guard(),
     )
     file_reader_factory = lambda root: FileSystemFileReader(root=root)
     deps = EpisodeDependencies(

--- a/noesis/domain/artifacts/__init__.py
+++ b/noesis/domain/artifacts/__init__.py
@@ -1,0 +1,15 @@
+"""Domain artifacts namespace."""
+
+from .immutability import (
+    ArtifactWriteMode,
+    ArtifactWriteRequest,
+    ImmutabilityDecision,
+    ImmutabilityError,
+)
+
+__all__ = [
+    "ArtifactWriteMode",
+    "ArtifactWriteRequest",
+    "ImmutabilityDecision",
+    "ImmutabilityError",
+]

--- a/noesis/domain/artifacts/immutability.py
+++ b/noesis/domain/artifacts/immutability.py
@@ -1,0 +1,65 @@
+"""Domain contracts for episode artifact immutability."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+__all__ = [
+    "ArtifactWriteMode",
+    "ArtifactWriteRequest",
+    "ImmutabilityDecision",
+    "ImmutabilityError",
+]
+
+
+class ArtifactWriteMode(str, Enum):
+    """Normalized write modes for episode artifacts."""
+
+    APPEND = "append"
+    CREATE = "create"
+    OVERWRITE = "overwrite"
+    SEAL = "seal"
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactWriteRequest:
+    """Describe an attempted artifact write."""
+
+    episode_dir: Path
+    artifact: str
+    mode: ArtifactWriteMode
+
+    @property
+    def run_dir(self) -> Path:
+        """Back-compat alias for episode_dir."""
+        return self.episode_dir
+
+
+@dataclass(frozen=True, slots=True)
+class ImmutabilityDecision:
+    """Outcome of an immutability guard check."""
+
+    allowed: bool
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.allowed and not self.reason:
+            raise ValueError("ImmutabilityDecision.reason required when disallowed")
+
+
+class ImmutabilityError(RuntimeError):
+    """Raised when a write violates the immutability policy."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        episode_dir: Path,
+        artifact: str,
+        mode: ArtifactWriteMode,
+    ) -> None:
+        super().__init__(message)
+        self.episode_dir = episode_dir
+        self.artifact = artifact
+        self.mode = mode

--- a/noesis/domain/verification.py
+++ b/noesis/domain/verification.py
@@ -56,6 +56,9 @@ class SnapshotMetadataStore(Protocol):
     def load(self, *, snapshots_dir: Path) -> SnapshotCaptureTimes | None:
         ...
 
+    def path_for(self, *, snapshots_dir: Path) -> Path:
+        ...
+
 
 @dataclass(frozen=True, slots=True)
 class SnapshotPaths:

--- a/noesis/infrastructure/__init__.py
+++ b/noesis/infrastructure/__init__.py
@@ -1,6 +1,15 @@
 """Infrastructure layer exports for Noēsis."""
 
-from . import config  # noqa: F401
-from .state_repository import RuntimeStateRepository  # noqa: F401
-
 __all__ = ["config", "RuntimeStateRepository"]
+
+
+def __getattr__(name: str):  # pragma: no cover - import shim
+    if name == "config":
+        from . import config as _config
+
+        return _config
+    if name == "RuntimeStateRepository":
+        from .state_repository import RuntimeStateRepository
+
+        return RuntimeStateRepository
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/noesis/infrastructure/immutability.py
+++ b/noesis/infrastructure/immutability.py
@@ -1,0 +1,21 @@
+"""Filesystem-backed immutability checks for episode artifacts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from noesis.interfaces.immutability import SealStatusPort
+from noesis.runtime.artifacts.manifest import MANIFEST_FILE_NAME
+
+__all__ = ["ManifestSealStatus"]
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestSealStatus(SealStatusPort):
+    """Treat presence of manifest.json as the episode seal."""
+
+    def is_sealed(self, run_dir: Path) -> bool:
+        return (run_dir / MANIFEST_FILE_NAME).exists()
+
+    def seal_marker(self, run_dir: Path) -> Path:
+        return run_dir / MANIFEST_FILE_NAME

--- a/noesis/infrastructure/snapshot/metadata_store.py
+++ b/noesis/infrastructure/snapshot/metadata_store.py
@@ -14,6 +14,9 @@ class FileSystemSnapshotMetadataStore:
 
     filename: str = "metadata.json"
 
+    def path_for(self, *, snapshots_dir: Path) -> Path:
+        return snapshots_dir / self.filename
+
     def save(self, *, snapshots_dir: Path, times: SnapshotCaptureTimes) -> Path:
         snapshots_dir.mkdir(parents=True, exist_ok=True)
         payload = json.dumps(
@@ -23,12 +26,12 @@ class FileSystemSnapshotMetadataStore:
             ensure_ascii=True,
             allow_nan=False,
         )
-        path = snapshots_dir / self.filename
+        path = self.path_for(snapshots_dir=snapshots_dir)
         path.write_text(payload, encoding="utf-8")
         return path
 
     def load(self, *, snapshots_dir: Path) -> SnapshotCaptureTimes | None:
-        path = snapshots_dir / self.filename
+        path = self.path_for(snapshots_dir=snapshots_dir)
         if not path.exists():
             return None
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/noesis/infrastructure/state_repository.py
+++ b/noesis/infrastructure/state_repository.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Literal, Protocol, Sequence, TYPE_CHECKING
 
 from noesis.runtime.serialization import atomic_write_json
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
 from noesis.runtime.normalization import normalize_using
 from noesis.domain.faculties.intuition import IntuitionMode
 from noesis.domain.process import ProcessKind
@@ -91,6 +93,11 @@ class RuntimeStateRepository(StateRepository):
 
 
 def _write_state(path: Path, state: NoesisState) -> None:
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=path.parent,
+        artifact=path.name,
+        mode=ArtifactWriteMode.OVERWRITE,
+    )
     payload = state.to_dict()
     episode = payload.get("episode")
     if isinstance(episode, dict):

--- a/noesis/interfaces/immutability.py
+++ b/noesis/interfaces/immutability.py
@@ -1,0 +1,17 @@
+"""Ports for artifact immutability checks."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+__all__ = ["SealStatusPort"]
+
+
+class SealStatusPort(Protocol):
+    """Port for checking whether an episode run has been sealed."""
+
+    def is_sealed(self, run_dir: Path) -> bool:
+        ...
+
+    def seal_marker(self, run_dir: Path) -> Path:
+        ...

--- a/noesis/runtime/artifacts/__init__.py
+++ b/noesis/runtime/artifacts/__init__.py
@@ -1,29 +1,4 @@
-"""
-Artifact integrity helpers: manifests, writers, and deterministic IDs.
-"""
-
-from .manifest import (
-    ArtifactFile,
-    ArtifactManifest,
-    ArtifactKind,
-    MANIFEST_FILE_NAME,
-    MANIFEST_SCHEMA_VERSION,
-    ManifestSignature,
-)
-from .writer import ManifestWriter, ManifestSigner
-from .verify import (
-    ManifestVerifier,
-    VerificationIssue,
-    VerificationReport,
-    FileVerification,
-)
-from .ids import (
-    EpisodeIds,
-    new_episode_ulid,
-    directive_uuid,
-    governance_uuid,
-)
-from .signing import HMACManifestSigner, HMACSignatureVerifier
+"""Artifact integrity helpers: manifests, writers, and deterministic IDs."""
 
 __all__ = [
     "ArtifactFile",
@@ -45,3 +20,34 @@ __all__ = [
     "HMACManifestSigner",
     "HMACSignatureVerifier",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - import shim
+    if name in {
+        "ArtifactFile",
+        "ArtifactManifest",
+        "ArtifactKind",
+        "MANIFEST_FILE_NAME",
+        "MANIFEST_SCHEMA_VERSION",
+        "ManifestSignature",
+    }:
+        from . import manifest as _manifest
+
+        return getattr(_manifest, name)
+    if name in {"ManifestWriter", "ManifestSigner"}:
+        from . import writer as _writer
+
+        return getattr(_writer, name)
+    if name in {"ManifestVerifier", "VerificationIssue", "VerificationReport", "FileVerification"}:
+        from . import verify as _verify
+
+        return getattr(_verify, name)
+    if name in {"EpisodeIds", "new_episode_ulid", "directive_uuid", "governance_uuid"}:
+        from . import ids as _ids
+
+        return getattr(_ids, name)
+    if name in {"HMACManifestSigner", "HMACSignatureVerifier"}:
+        from . import signing as _signing
+
+        return getattr(_signing, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/noesis/runtime/artifacts/immutability.py
+++ b/noesis/runtime/artifacts/immutability.py
@@ -1,0 +1,27 @@
+"""Runtime helpers for episode artifact immutability enforcement."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from noesis.infrastructure.immutability import ManifestSealStatus
+from noesis.usecases.immutability import ArtifactImmutabilityGuard
+
+APPEND_ONLY_ARTIFACTS = frozenset(
+    {
+        "events.jsonl",
+        "prompts.jsonl",
+        "learn.jsonl",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def default_artifact_guard() -> ArtifactImmutabilityGuard:
+    """Return a shared immutability guard for episode artifact writers."""
+    return ArtifactImmutabilityGuard(
+        seal_status=ManifestSealStatus(),
+        append_only=APPEND_ONLY_ARTIFACTS,
+    )
+
+
+__all__ = ["APPEND_ONLY_ARTIFACTS", "default_artifact_guard"]

--- a/noesis/runtime/artifacts/writer.py
+++ b/noesis/runtime/artifacts/writer.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Dict, Iterator, Protocol
 
 from noesis.runtime.serialization import atomic_write_text
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
 
 from .manifest import (
     ArtifactFile,
@@ -92,6 +94,11 @@ class ManifestWriter:
             signature = signer.sign(unsigned, canonical.encode("utf-8"))
             manifest = replace(manifest, signer=getattr(signer, "name", signature.key_id), signature=signature)
             payload = manifest.canonical_json()
+        default_artifact_guard().ensure_write_allowed(
+            episode_dir=self._run_dir,
+            artifact=MANIFEST_FILE_NAME,
+            mode=ArtifactWriteMode.SEAL,
+        )
         atomic_write_text(self.manifest_path, payload)
         return manifest
 

--- a/noesis/runtime/learning.py
+++ b/noesis/runtime/learning.py
@@ -20,6 +20,8 @@ from noesis.domain.learning.model import (
     derive_target_key,
 )
 from noesis.trace.events import write_event
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
 
 from .config_provider import get_config_port
 from .events import last_event_of_phase
@@ -51,6 +53,11 @@ def _sanitize_policy_id(policy_id: str) -> str:
 def ensure_learn_file(run_dir: Path) -> Path:
     """Create learn.jsonl if it is missing (empty file is valid)."""
     path = run_dir / "learn.jsonl"
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=run_dir,
+        artifact=path.name,
+        mode=ArtifactWriteMode.CREATE,
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
         path.touch()
@@ -96,6 +103,11 @@ def persist_episode_learning(
     payload: Dict[str, Any],
 ) -> None:
     path = run_dir / "learn.jsonl"
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=run_dir,
+        artifact=path.name,
+        mode=ArtifactWriteMode.APPEND,
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     record_id = payload.get("id") or f"episode:{episode_id}"
     record = {

--- a/noesis/runtime/prompt_recorder.py
+++ b/noesis/runtime/prompt_recorder.py
@@ -7,9 +7,10 @@ from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
 from typing import Callable, Literal, Mapping, TYPE_CHECKING
-import warnings
 
-from noesis.trace.events import canonical_dumps
+from noesis.runtime.serialization import canonical_dumps
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
 
 if TYPE_CHECKING:
     from noesis.infrastructure.state_repository import EpisodeContext
@@ -42,25 +43,13 @@ def _fingerprint(rendered: str) -> tuple[str, str]:
     return f"sha256:{digest}", normalized
 
 
-def _ensure_manifest_open(run_dir: Path) -> None:
-    """
-    Prevent writes after manifest finalization.
-
-    Aligns with events.jsonl behavior to avoid mutating a sealed run directory.
-    """
-    manifest_path = run_dir / "manifest.json"
-    if manifest_path.exists():
-        warnings.warn(
-            f"Manifest {manifest_path} already exists; refusing to append prompts.",
-            RuntimeWarning,
-            stacklevel=3,
-        )
-        raise RuntimeError("cannot append prompts after manifest is finalized")
-
-
 def _append_prompt(run_dir: Path, record: Mapping[str, object]) -> None:
     """Append a single prompt record to prompts.jsonl."""
-    _ensure_manifest_open(run_dir)
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=run_dir,
+        artifact=PROMPTS_FILE_NAME,
+        mode=ArtifactWriteMode.APPEND,
+    )
     run_dir.mkdir(parents=True, exist_ok=True)
     payload = canonical_dumps(record)
     with (run_dir / PROMPTS_FILE_NAME).open("a", encoding="utf-8") as handle:

--- a/noesis/runtime/serialization.py
+++ b/noesis/runtime/serialization.py
@@ -19,11 +19,29 @@ import os
 import tempfile
 
 from noesis._fs import fsync_dir
-from noesis.trace.events import canonical_dumps
 
 JsonDefault = Callable[[Any], Any]
 
 __all__ = ["canonical_dumps", "atomic_write_json", "atomic_write_text"]
+
+
+def canonical_dumps(value: Any, *, default: JsonDefault | None = None) -> str:
+    """
+    Render a JSON string with stable ordering and formatting.
+
+    - ensure_ascii=False to preserve UTF-8
+    - sort_keys=True for deterministic key order
+    - separators=(",", ":") for compact, consistent output
+    """
+    import json
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=default,
+    )
 
 
 def atomic_write_json(path: Path, value: Any, *, default: JsonDefault | None = None) -> None:

--- a/noesis/runtime/summary.py
+++ b/noesis/runtime/summary.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, Optional, List
 import hashlib
 
 from noesis.state.episode import EpisodeSummary
-from noesis.trace.events import read_events, write_event, canonical_dumps
+from noesis.trace.events import read_events, write_event
+from noesis.runtime.serialization import canonical_dumps
 from noesis.trace.summary import write_summary
 from noesis.domain.faculties import validate_hook_sequence
 from noesis.intuition import Intuition, IntuitionMode

--- a/noesis/trace/events.py
+++ b/noesis/trace/events.py
@@ -22,35 +22,18 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Callable
 import json
-import warnings
 
 from datetime import datetime
 from uuid import uuid4
 
 from noesis.domain.state.cognitive import CognitiveEvent
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
+from noesis.runtime.serialization import canonical_dumps
 
 JsonDefault = Callable[[Any], Any]
 
-
-def canonical_dumps(value: Any, *, default: JsonDefault | None = None) -> str:
-    """
-    Render a JSON string with stable ordering and formatting.
-
-    - ensure_ascii=False to preserve UTF-8
-    - sort_keys=True for deterministic key order
-    - separators=(",", ":") for compact, consistent output
-    """
-    return json.dumps(
-        value,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-        default=default,
-    )
-
 EVENTS_FILE = "events.jsonl"
-_MANIFEST_FILE = "manifest.json"
-
 # Canonical phases for event.phase
 VERB_PHASES: set[str] = {
     "observe",
@@ -215,7 +198,11 @@ def write_event(dir_path: Path, event: Dict[str, Any], *, validate: bool = True)
         event["faculty"] = FACULTY_PHASES[phase]
     if validate:
         _validate_event_schema(event)
-    _ensure_manifest_not_sealed(dir_path)
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=dir_path,
+        artifact=EVENTS_FILE,
+        mode=ArtifactWriteMode.APPEND,
+    )
     dir_path.mkdir(parents=True, exist_ok=True)
     payload = canonical_dumps(event)
     with (dir_path / EVENTS_FILE).open("a", encoding="utf-8") as f:
@@ -340,14 +327,3 @@ def is_terminate_event(event: Dict[str, Any]) -> bool:
     payload = event.get("payload") or {}
     kind = payload.get("kind") or payload.get("type") or payload.get("event")
     return kind == "terminate"
-
-
-def _ensure_manifest_not_sealed(dir_path: Path) -> None:
-    manifest_path = dir_path / _MANIFEST_FILE
-    if manifest_path.exists():
-        warnings.warn(
-            f"Manifest {manifest_path} already exists; refusing to append events.",
-            RuntimeWarning,
-            stacklevel=3,
-        )
-        raise RuntimeError("cannot append events after manifest is finalized")

--- a/noesis/trace/summary.py
+++ b/noesis/trace/summary.py
@@ -21,6 +21,8 @@ from typing import Any, Dict
 import json
 
 from noesis.runtime.serialization import atomic_write_json
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.runtime.artifacts.immutability import default_artifact_guard
 
 SUMMARY_FILE = "summary.json"
 
@@ -57,6 +59,11 @@ def _prune_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
 
 def write_summary(dir_path: Path, summary: Dict[str, Any]) -> None:
     """Atomically write `summary.json` under the given episode directory."""
+    default_artifact_guard().ensure_write_allowed(
+        episode_dir=dir_path,
+        artifact=SUMMARY_FILE,
+        mode=ArtifactWriteMode.OVERWRITE,
+    )
     _atomic_write_json(dir_path / SUMMARY_FILE, _prune_summary(summary))
 
 

--- a/noesis/usecases/__init__.py
+++ b/noesis/usecases/__init__.py
@@ -14,11 +14,10 @@ __all__ = [
     "EpisodeOutcome",
 ]
 
-from .episode_runner import (
-    EpisodeDependencies,
-    EpisodeInstrumentation,
-    EpisodeOutcome,
-    EpisodeRequest,
-    EpisodeResult,
-    EpisodeRunner,
-)
+
+def __getattr__(name: str):  # pragma: no cover - import shim
+    if name in __all__:
+        from . import episode_runner as _episode_runner
+
+        return getattr(_episode_runner, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/noesis/usecases/immutability.py
+++ b/noesis/usecases/immutability.py
@@ -1,0 +1,106 @@
+"""Use-case guard for enforcing episode artifact immutability."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+from noesis.domain.artifacts.immutability import (
+    ArtifactWriteMode,
+    ArtifactWriteRequest,
+    ImmutabilityDecision,
+    ImmutabilityError,
+)
+from noesis.interfaces.immutability import SealStatusPort
+
+__all__ = ["ArtifactImmutabilityGuard"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactImmutabilityGuard:
+    """Centralized policy guard for episode artifact writes."""
+
+    seal_status: SealStatusPort
+    append_only: frozenset[str] = frozenset()
+
+    def check(self, request: ArtifactWriteRequest) -> ImmutabilityDecision:
+        run_dir = request.episode_dir
+        artifact = request.artifact
+        mode = request.mode
+        if self.seal_status.is_sealed(run_dir):
+            marker = self.seal_status.seal_marker(run_dir)
+            reason = f"episode sealed by {marker}"
+            return ImmutabilityDecision(allowed=False, reason=reason)
+        if artifact in self.append_only and mode is ArtifactWriteMode.OVERWRITE:
+            return ImmutabilityDecision(
+                allowed=False,
+                reason=f"append-only artifact requires append: {artifact}",
+            )
+        if artifact not in self.append_only and mode is ArtifactWriteMode.APPEND:
+            return ImmutabilityDecision(
+                allowed=False,
+                reason=f"append-only write requested for non-append artifact: {artifact}",
+            )
+        return ImmutabilityDecision(allowed=True, reason=None)
+
+    def ensure_write_allowed(
+        self,
+        *,
+        episode_dir: Path,
+        artifact: str,
+        mode: ArtifactWriteMode,
+    ) -> None:
+        normalized = _normalize_artifact_path(artifact, episode_dir=episode_dir)
+        request = ArtifactWriteRequest(episode_dir=episode_dir, artifact=normalized, mode=mode)
+        decision = self.check(request)
+        if decision.allowed:
+            return
+        reason = decision.reason
+        message = f"{reason}; refusing to {mode.value} {normalized}"
+        raise ImmutabilityError(
+            message,
+            episode_dir=episode_dir,
+            artifact=normalized,
+            mode=mode,
+        )
+
+
+def _normalize_artifact_path(raw: str, *, episode_dir: Path) -> str:
+    """
+    Normalize and validate an artifact path.
+
+    - Reject absolute paths.
+    - Reject any '..' segments.
+    - Normalize to POSIX separators.
+    """
+    if not raw:
+        raise ImmutabilityError(
+            "artifact path is required",
+            episode_dir=episode_dir,
+            artifact=raw,
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
+    normalized = str(raw).replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or normalized.startswith("/"):
+        raise ImmutabilityError(
+            f"artifact path must be relative: {raw}",
+            episode_dir=episode_dir,
+            artifact=raw,
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
+    if path.parts and ":" in path.parts[0]:
+        raise ImmutabilityError(
+            f"artifact path must be relative: {raw}",
+            episode_dir=episode_dir,
+            artifact=raw,
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
+    if ".." in path.parts:
+        raise ImmutabilityError(
+            f"artifact path must not escape episode dir: {raw}",
+            episode_dir=episode_dir,
+            artifact=raw,
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
+    return path.as_posix().lstrip("./")

--- a/noesis/usecases/snapshot_artifacts.py
+++ b/noesis/usecases/snapshot_artifacts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Literal, Sequence
 
 from noesis.domain.snapshot import DEFAULT_IGNORE, Snapshot, SnapshotGateway
+from noesis.domain.artifacts.immutability import ArtifactWriteMode
+from noesis.usecases.immutability import ArtifactImmutabilityGuard
 from noesis.domain.verification import (
     SnapshotCaptureTimes,
     SnapshotClock,
@@ -26,6 +28,7 @@ class SnapshotArtifactWriter:
     gateway: SnapshotGateway
     metadata_store: SnapshotMetadataStore
     clock: SnapshotClock
+    immutability_guard: ArtifactImmutabilityGuard
 
     def capture_and_store(
         self,
@@ -39,6 +42,11 @@ class SnapshotArtifactWriter:
         snapshots_dir = run_dir / "snapshots"
         snapshots_dir.mkdir(parents=True, exist_ok=True)
         snapshot_path = snapshots_dir / f"{phase}.json"
+        self.immutability_guard.ensure_write_allowed(
+            episode_dir=run_dir,
+            artifact=str(snapshot_path.relative_to(run_dir).as_posix()),
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
         self.gateway.save(snapshot, snapshot_path)
 
         # Capture completed time to align timestamps with persisted artifacts.
@@ -48,6 +56,12 @@ class SnapshotArtifactWriter:
             times = times.with_pre(timestamp)
         else:
             times = times.with_post(timestamp)
+        metadata_path = self.metadata_store.path_for(snapshots_dir=snapshots_dir)
+        self.immutability_guard.ensure_write_allowed(
+            episode_dir=run_dir,
+            artifact=str(metadata_path.relative_to(run_dir).as_posix()),
+            mode=ArtifactWriteMode.OVERWRITE,
+        )
         self.metadata_store.save(snapshots_dir=snapshots_dir, times=times)
         return snapshot
 

--- a/tests/runtime/test_artifacts.py
+++ b/tests/runtime/test_artifacts.py
@@ -10,6 +10,11 @@ from noesis.runtime.artifacts.verify import ManifestVerifier
 from noesis.runtime.artifacts.signing import HMACManifestSigner, HMACSignatureVerifier
 from noesis.runtime.artifacts.manifest import MANIFEST_FILE_NAME
 from noesis.trace.events import write_event
+from noesis.trace.summary import write_summary
+from noesis.runtime.learning import ensure_learn_file, persist_episode_learning
+from noesis.runtime.prompt_recorder import PromptRecorder
+from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
+from noesis.domain.artifacts.immutability import ImmutabilityError
 
 
 def _write_json(path: Path, payload: str) -> None:
@@ -120,8 +125,84 @@ def test_write_event_after_manifest_fails(tmp_path: Path) -> None:
         "payload": {},
         "evidence_ids": [],
     }
-    with pytest.warns(RuntimeWarning), pytest.raises(RuntimeError):
+    with pytest.raises(ImmutabilityError) as exc:
         write_event(run_dir, event, validate=False)
+    assert "episode sealed" in str(exc.value)
+
+
+def test_append_only_allows_events_pre_seal(tmp_path: Path) -> None:
+    run_dir = tmp_path / "ep_events"
+    run_dir.mkdir()
+    event = {
+        "timestamp": "2024-01-01T00:00:00Z",
+        "episode_id": "ep_events",
+        "phase": "test",
+        "payload": {},
+        "evidence_ids": [],
+    }
+    write_event(run_dir, dict(event), validate=False)
+    write_event(run_dir, dict(event), validate=False)
+
+
+def test_summary_state_and_learn_writes_block_after_seal(tmp_path: Path) -> None:
+    run_dir = tmp_path / "ep_state"
+    run_dir.mkdir()
+
+    write_summary(run_dir, {"schema_version": "1.0.0", "episode_id": "ep_state"})
+
+    ctx = EpisodeContext(
+        run_dir=run_dir,
+        episode_id="ep_state",
+        seed=0,
+        task="test",
+        tags={},
+        adapter_label="adapter:test",
+        started_at="2024-01-01T00:00:00Z",
+    )
+    repo = RuntimeStateRepository(context=ctx)
+    state = repo.init()
+
+    ensure_learn_file(run_dir)
+    persist_episode_learning(
+        run_dir,
+        episode_id="ep_state",
+        agent_id="system",
+        payload={"policy_id": "policy:test"},
+    )
+
+    ManifestWriter(run_dir=run_dir, episode_id="ep_state").finalize()
+
+    with pytest.raises(ImmutabilityError) as exc:
+        write_summary(run_dir, {"schema_version": "1.0.0", "episode_id": "ep_state"})
+    assert "episode sealed" in str(exc.value)
+    with pytest.raises(ImmutabilityError):
+        repo.persist(state)
+    with pytest.raises(ImmutabilityError):
+        ensure_learn_file(run_dir)
+    with pytest.raises(ImmutabilityError):
+        persist_episode_learning(
+            run_dir,
+            episode_id="ep_state",
+            agent_id="system",
+            payload={"policy_id": "policy:test"},
+        )
+
+
+def test_prompt_recording_blocked_after_seal(tmp_path: Path) -> None:
+    run_dir = tmp_path / "ep_prompt_seal"
+    run_dir.mkdir()
+    recorder = PromptRecorder(
+        run_dir=run_dir,
+        episode_id="ep_prompt_seal",
+        enabled=True,
+        mode="hash_only",
+    )
+    recorder.record(phase="observe", agent_id="tester", rendered="hi")
+
+    ManifestWriter(run_dir=run_dir, episode_id="ep_prompt_seal").finalize()
+
+    with pytest.raises(ImmutabilityError):
+        recorder.record(phase="observe", agent_id="tester", rendered="blocked")
 
 
 def test_manifest_signatures_survive_canonicalization(tmp_path: Path) -> None:

--- a/tests/usecases/test_episode_runner_verification.py
+++ b/tests/usecases/test_episode_runner_verification.py
@@ -15,12 +15,14 @@ from noesis.infrastructure.snapshot import (
     FileSystemSnapshotMetadataStore,
     UtcSnapshotClock,
 )
+from noesis.infrastructure.immutability import ManifestSealStatus
 from noesis.infrastructure.state_repository import EpisodeContext, RuntimeStateRepository
 from noesis.infrastructure.verification import FileSystemFileReader
 from noesis.interfaces.config import ConfigSnapshot
 from noesis.runtime.summary import finalize_summary
 from noesis.trace.schema import SUMMARY_SCHEMA_VERSION
 from noesis.usecases.episode_runner import EpisodeDependencies, EpisodeRequest, EpisodeRunner
+from noesis.usecases.immutability import ArtifactImmutabilityGuard
 from noesis.usecases.snapshot_artifacts import SnapshotArtifactWriter
 
 
@@ -112,6 +114,7 @@ def _run_episode(
             gateway=FileSystemSnapshotGateway(),
             metadata_store=FileSystemSnapshotMetadataStore(),
             clock=UtcSnapshotClock(),
+            immutability_guard=ArtifactImmutabilityGuard(ManifestSealStatus()),
         ),
         file_reader_factory=lambda root: FileSystemFileReader(root=root),
     )

--- a/tests/usecases/test_snapshot_artifacts.py
+++ b/tests/usecases/test_snapshot_artifacts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from noesis.infrastructure.snapshot.clock import UtcSnapshotClock
 from noesis.infrastructure.snapshot.file_system_gateway import FileSystemSnapshotGateway
 from noesis.infrastructure.snapshot.metadata_store import FileSystemSnapshotMetadataStore
+from noesis.infrastructure.immutability import ManifestSealStatus
+from noesis.usecases.immutability import ArtifactImmutabilityGuard
 from noesis.usecases.snapshot_artifacts import SnapshotArtifactWriter, SnapshotClock
 
 
@@ -38,6 +40,7 @@ def test_snapshot_artifact_writer_records_capture_times(tmp_path: Path) -> None:
         gateway=FileSystemSnapshotGateway(),
         metadata_store=FileSystemSnapshotMetadataStore(),
         clock=clock,
+        immutability_guard=ArtifactImmutabilityGuard(ManifestSealStatus()),
     )
 
     writer.capture_and_store(phase="pre", workspace=workspace, run_dir=run_dir)


### PR DESCRIPTION
## Summary

This PR makes episode artifact immutability contracts and enforcement stricter, safer, and easier to reason about. It also resolves an import-cycle issue introduced by broadly wiring the immutability guard.

### What changed

#### Immutability contracts + policy plumbing
- Added/updated immutability domain contracts (`episode_dir`, denial reasons enforced, richer errors).
- Introduced an application-layer guard with safe-path normalization and strict policy checks.
- Implemented filesystem-backed seal/finalization status lookup and runtime composition defaults.
- Files:
  - `noesis/domain/artifacts/__init__.py`
  - `noesis/domain/artifacts/immutability.py`
  - `noesis/interfaces/immutability.py`
  - `noesis/usecases/immutability.py`
  - `noesis/infrastructure/immutability.py`
  - `noesis/runtime/artifacts/immutability.py`

#### Guarded every episode writer
Wired the immutability guard into all code paths that write episode artifacts, including:
- Events append (`events.jsonl`)
- Summary/state overwrites (`summary.json`, state artifacts)
- Prompt recording (`prompts.jsonl`)
- Learning artifacts (`learn.jsonl`)
- Snapshot artifact writes (including metadata store paths)
- Manifest sealing/finalization write path
- Files:
  - `noesis/trace/events.py`
  - `noesis/trace/summary.py`
  - `noesis/infrastructure/state_repository.py`
  - `noesis/runtime/prompt_recorder.py`
  - `noesis/runtime/learning.py`
  - `noesis/usecases/snapshot_artifacts.py`
  - `noesis/runtime/artifacts/writer.py`
  - `noesis/core.py`

#### Snapshot metadata path contract
- Snapshot metadata store now exposes a path contract suitable for guard enforcement.
- Files:
  - `noesis/domain/verification.py`
  - `noesis/infrastructure/snapshot/metadata_store.py`

#### Import cycle resolution via lazy exports
- Removed eager imports in package initializers and replaced with lazy `__getattr__` shims to avoid
  import-time cycles when importing immutability modules.
- Files:
  - `noesis/usecases/__init__.py`
  - `noesis/infrastructure/__init__.py`
  - `noesis/runtime/artifacts/__init__.py`

#### Supporting runtime changes
- Updated runtime serialization/summary pipelines to align with guarded writes and episode_dir naming.
- Files:
  - `noesis/runtime/serialization.py`
  - `noesis/runtime/summary.py`

### Why this matters
- Prevents Episode/Run terminology drift by making the contract normative (`episode_dir`).
- Makes immutability enforcement safer by rejecting absolute paths and `..` traversal and normalizing
  all artifact paths to a consistent relative POSIX form.
- Improves diagnosability and operator trust via richer error context and deterministic denial reasons.
- Stabilizes imports and avoids brittle import-time cycles as the system scales.

### Tests
All requested tests passed:
- `uv run --group dev python -m pytest tests/runtime/test_artifacts.py`
- `uv run --group dev python -m pytest tests/usecases/test_snapshot_artifacts.py`
- `uv run --group dev python -m pytest tests/usecases/test_episode_runner_verification.py`